### PR TITLE
[package] Improve props field stylings

### DIFF
--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -162,17 +162,19 @@ progressPlayground isDarkMode pm =
         { isDarkMode = isDarkMode
         , preview = Progress.progressWithProps pm
         , props =
-            [ Props.field
-                { label = "Bar"
-                , props =
-                    Props.counter
-                        { value = pm.value
-                        , toString = \value -> String.fromFloat value ++ "%"
-                        , onClickPlus = ProgressMsg Progress.CounterPlus
-                        , onClickMinus = ProgressMsg Progress.CounterMinus
-                        }
-                , note = "A progress element can contain a bar visually indicating progress"
-                }
+            [ Props.FieldSet ""
+                [ Props.field
+                    { label = "Bar"
+                    , props =
+                        Props.counter
+                            { value = pm.value
+                            , toString = \value -> String.fromFloat value ++ "%"
+                            , onClickPlus = ProgressMsg Progress.CounterPlus
+                            , onClickMinus = ProgressMsg Progress.CounterMinus
+                            }
+                    }
+                , Props.comment "A progress element can contain a bar visually indicating progress"
+                ]
             , Props.FieldSet "Config"
                 [ Props.field
                     { label = "Types"
@@ -199,8 +201,8 @@ progressPlayground isDarkMode pm =
                                 )
                                     |> UpdateProgress
                             }
-                    , note = "An indicating progress bar visually indicates the current level of progress of a task"
                     }
+                , Props.comment "An indicating progress bar visually indicates the current level of progress of a task"
                 , Props.field
                     { label = "States"
                     , props =
@@ -233,26 +235,27 @@ progressPlayground isDarkMode pm =
                                 )
                                     >> UpdateProgress
                             }
-                    , note =
-                        case pm.state of
-                            Active ->
-                                "A progress bar can show activity"
-
-                            Success ->
-                                "A progress bar can show a success state"
-
-                            Warning ->
-                                "A progress bar can show a warning state"
-
-                            Error ->
-                                "A progress bar can show an error state"
-
-                            Disabled ->
-                                "A progress bar can be disabled"
-
-                            _ ->
-                                ""
                     }
+                , Props.comment
+                    (case pm.state of
+                        Active ->
+                            "A progress bar can show activity"
+
+                        Success ->
+                            "A progress bar can show a success state"
+
+                        Warning ->
+                            "A progress bar can show a warning state"
+
+                        Error ->
+                            "A progress bar can show an error state"
+
+                        Disabled ->
+                            "A progress bar can be disabled"
+
+                        _ ->
+                            ""
+                    )
                 ]
             , Props.FieldSet "Content"
                 [ Props.field
@@ -263,8 +266,8 @@ progressPlayground isDarkMode pm =
                             , onInput = (\string ps -> { ps | unit = string }) >> UpdateProgress
                             , placeholder = ""
                             }
-                    , note = "A progress bar can contain a text value indicating current progress"
                     }
+                , Props.comment "A progress bar can contain a text value indicating current progress"
                 , Props.field
                     { label = "Caption"
                     , props =
@@ -273,8 +276,8 @@ progressPlayground isDarkMode pm =
                             , onInput = (\string ps -> { ps | caption = string }) >> UpdateProgress
                             , placeholder = ""
                             }
-                    , note = "A progress element can contain a label"
                     }
+                , Props.comment "A progress element can contain a label"
                 ]
             ]
         }
@@ -338,7 +341,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                             )
                                 >> UpdateTypography
                         }
-                , note = ""
                 }
             , Props.FieldSet "Typography"
                 [ Props.field
@@ -364,7 +366,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                 )
                                     >> UpdateTypography
                             }
-                    , note = ""
                     }
                 , Props.field
                     { label = "font-size"
@@ -389,7 +390,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                         }
                                     )
                             }
-                    , note = ""
                     }
                 , Props.field
                     { label = "font-style"
@@ -414,7 +414,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                 )
                                     >> UpdateTypography
                             }
-                    , note = ""
                     }
                 , Props.field
                     { label = "font-weight"
@@ -445,7 +444,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                 )
                                     >> UpdateTypography
                             }
-                    , note = ""
                     }
                 , Props.field
                     { label = "text-align"
@@ -492,7 +490,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                 )
                                     >> UpdateTypography
                             }
-                    , note = ""
                     }
                 , Props.field
                     { label = "line-height"
@@ -517,7 +514,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                         }
                                     )
                             }
-                    , note = ""
                     }
                 , Props.field
                     { label = "text-decoration"
@@ -542,7 +538,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                 )
                                     >> UpdateTypography
                             }
-                    , note = ""
                     }
                 , Props.field
                     { label = "letter-spacing"
@@ -567,7 +562,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                         }
                                     )
                             }
-                    , note = ""
                     }
                 , Props.field
                     { label = "text-transform"
@@ -598,7 +592,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                 )
                                     >> UpdateTypography
                             }
-                    , note = ""
                     }
                 ]
             , Props.FieldSet "TextBlock"
@@ -631,7 +624,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                 )
                                     >> UpdateTypography
                             }
-                    , note = ""
                     }
                 , Props.field
                     { label = "overflow-wrap"
@@ -659,7 +651,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                                 )
                                     >> UpdateTypography
                             }
-                    , note = ""
                     }
                 ]
             ]

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -312,7 +312,7 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
             [ Props.field
                 { label = "-webkit-font-smoothing"
                 , props =
-                    Props.radio
+                    Props.select
                         { value = tm.webkitFontSmoothing |> Typography.webkitFontSmoothingToString
                         , options = [ "auto", "none", "antialiased", "subpixel-antialiased" ]
                         , onChange =
@@ -419,7 +419,7 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                 , Props.field
                     { label = "font-weight"
                     , props =
-                        Props.radio
+                        Props.select
                             { value = tm.typography.font.weight |> Maybe.map .value |> Maybe.withDefault "-"
                             , options = [ Css.lighter.value, Css.normal.value, Css.bold.value, Css.bolder.value ]
                             , onChange =
@@ -572,7 +572,7 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                 , Props.field
                     { label = "text-transform"
                     , props =
-                        Props.radio
+                        Props.select
                             { value = tm.typography.textSetting.textTransform |> Maybe.map .value |> Maybe.withDefault "-"
                             , options = [ Css.none.value, Css.uppercase.value, Css.lowercase.value, Css.capitalize.value ]
                             , onChange =
@@ -605,7 +605,7 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                 [ Props.field
                     { label = "word-break"
                     , props =
-                        Props.radio
+                        Props.select
                             { value = tm.typography.textBlock.wordBreak |> Maybe.map Typography.wordBreakToString |> Maybe.withDefault "-"
                             , options = [ "normal", "break-all", "keep-all", "auto-phrase" ]
                             , onChange =
@@ -636,7 +636,7 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                 , Props.field
                     { label = "overflow-wrap"
                     , props =
-                        Props.radio
+                        Props.select
                             { value = tm.typography.textBlock.overflowWrap |> Maybe.map Typography.overflowWrapToString |> Maybe.withDefault "-"
                             , options = [ "normal", "break-word", "anywhere" ]
                             , onChange =

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -162,22 +162,20 @@ progressPlayground isDarkMode pm =
         { isDarkMode = isDarkMode
         , preview = Progress.progressWithProps pm
         , props =
-            [ Props.FieldSet "Bar"
+            [ Props.field
+                { label = "Bar"
+                , props =
+                    Props.counter
+                        { value = pm.value
+                        , toString = \value -> String.fromFloat value ++ "%"
+                        , onClickPlus = ProgressMsg Progress.CounterPlus
+                        , onClickMinus = ProgressMsg Progress.CounterMinus
+                        }
+                , note = "A progress element can contain a bar visually indicating progress"
+                }
+            , Props.FieldSet "Config"
                 [ Props.field
-                    { label = ""
-                    , props =
-                        Props.counter
-                            { value = pm.value
-                            , toString = \value -> String.fromFloat value ++ "%"
-                            , onClickPlus = ProgressMsg Progress.CounterPlus
-                            , onClickMinus = ProgressMsg Progress.CounterMinus
-                            }
-                    , note = "A progress element can contain a bar visually indicating progress"
-                    }
-                ]
-            , Props.FieldSet "Types"
-                [ Props.field
-                    { label = ""
+                    { label = "Types"
                     , props =
                         Props.bool
                             { label = "Indicating"
@@ -203,10 +201,8 @@ progressPlayground isDarkMode pm =
                             }
                     , note = "An indicating progress bar visually indicates the current level of progress of a task"
                     }
-                ]
-            , Props.FieldSet "States"
-                [ Props.field
-                    { label = ""
+                , Props.field
+                    { label = "States"
                     , props =
                         Props.select
                             { value = Progress.stateToString pm.state

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -174,9 +174,9 @@ progressPlayground isDarkMode pm =
                 , Props.comment "A progress element can contain a bar visually indicating progress"
                 ]
             , Props.FieldSet "Config"
-                [ Props.field "Types"
+                [ Props.field "Indicating"
                     (Props.bool
-                        { label = "Indicating"
+                        { id = "indicating"
                         , value = pm.indicating
                         , onClick =
                             (\c ->

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -691,7 +691,8 @@ playground { isDarkMode, preview, props } =
             [ preview ]
         , div
             [ css
-                [ padding (Css.em 0.5)
+                [ alignSelf start
+                , padding (Css.em 0.5)
                 , displayFlex
                 , flexDirection column
                 , rowGap (Css.em 0.5)

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -163,79 +163,73 @@ progressPlayground isDarkMode pm =
         , preview = Progress.progressWithProps pm
         , props =
             [ Props.FieldSet ""
-                [ Props.field
-                    { label = "Bar"
-                    , props =
-                        Props.counter
-                            { value = pm.value
-                            , toString = \value -> String.fromFloat value ++ "%"
-                            , onClickPlus = ProgressMsg Progress.CounterPlus
-                            , onClickMinus = ProgressMsg Progress.CounterMinus
-                            }
-                    }
+                [ Props.field "Bar"
+                    (Props.counter
+                        { value = pm.value
+                        , toString = \value -> String.fromFloat value ++ "%"
+                        , onClickPlus = ProgressMsg Progress.CounterPlus
+                        , onClickMinus = ProgressMsg Progress.CounterMinus
+                        }
+                    )
                 , Props.comment "A progress element can contain a bar visually indicating progress"
                 ]
             , Props.FieldSet "Config"
-                [ Props.field
-                    { label = "Types"
-                    , props =
-                        Props.bool
-                            { label = "Indicating"
-                            , value = pm.indicating
-                            , onClick =
-                                (\c ->
-                                    let
-                                        newIndicating =
-                                            not c.indicating
-                                    in
-                                    { c
-                                        | indicating = newIndicating
-                                        , caption =
-                                            if newIndicating then
-                                                c.caption
+                [ Props.field "Types"
+                    (Props.bool
+                        { label = "Indicating"
+                        , value = pm.indicating
+                        , onClick =
+                            (\c ->
+                                let
+                                    newIndicating =
+                                        not c.indicating
+                                in
+                                { c
+                                    | indicating = newIndicating
+                                    , caption =
+                                        if newIndicating then
+                                            c.caption
 
-                                            else
-                                                "Uploading Files"
-                                    }
-                                        |> Progress.updateCaptionOnIndicating
-                                )
-                                    |> UpdateProgress
-                            }
-                    }
+                                        else
+                                            "Uploading Files"
+                                }
+                                    |> Progress.updateCaptionOnIndicating
+                            )
+                                |> UpdateProgress
+                        }
+                    )
                 , Props.comment "An indicating progress bar visually indicates the current level of progress of a task"
-                , Props.field
-                    { label = "States"
-                    , props =
-                        Props.select
-                            { value = Progress.stateToString pm.state
-                            , options = List.map Progress.stateToString [ Default, Active, Success, Warning, Error, Disabled ]
-                            , onChange =
-                                (\prevState ps ->
-                                    Progress.stateFromString prevState
-                                        |> Maybe.map
-                                            (\state ->
-                                                { ps
-                                                    | state = state
-                                                    , caption =
-                                                        case state of
-                                                            Success ->
-                                                                "Everything worked, your file is all ready."
+                , Props.field "States"
+                    (Props.select
+                        { value = Progress.stateToString pm.state
+                        , options = List.map Progress.stateToString [ Default, Active, Success, Warning, Error, Disabled ]
+                        , onChange =
+                            (\prevState ps ->
+                                Progress.stateFromString prevState
+                                    |> Maybe.map
+                                        (\state ->
+                                            { ps
+                                                | state = state
+                                                , caption =
+                                                    case state of
+                                                        Success ->
+                                                            "Everything worked, your file is all ready."
 
-                                                            Warning ->
-                                                                "Your file didn't meet the minimum resolution requirements."
+                                                        Warning ->
+                                                            "Your file didn't meet the minimum resolution requirements."
 
-                                                            Error ->
-                                                                "There was an error."
+                                                        Error ->
+                                                            "There was an error."
 
-                                                            _ ->
-                                                                ps.caption
-                                                }
-                                            )
-                                        |> Maybe.withDefault ps
-                                )
-                                    >> UpdateProgress
-                            }
-                    }
+                                                        _ ->
+                                                            ps.caption
+                                            }
+                                        )
+                                    |> Maybe.withDefault ps
+                            )
+                                >> UpdateProgress
+                        }
+                    )
                 , Props.comment
                     (case pm.state of
                         Active ->
@@ -258,25 +252,21 @@ progressPlayground isDarkMode pm =
                     )
                 ]
             , Props.FieldSet "Content"
-                [ Props.field
-                    { label = "Unit"
-                    , props =
-                        Props.string
-                            { value = pm.unit
-                            , onInput = (\string ps -> { ps | unit = string }) >> UpdateProgress
-                            , placeholder = ""
-                            }
-                    }
+                [ Props.field "Unit"
+                    (Props.string
+                        { value = pm.unit
+                        , onInput = (\string ps -> { ps | unit = string }) >> UpdateProgress
+                        , placeholder = ""
+                        }
+                    )
                 , Props.comment "A progress bar can contain a text value indicating current progress"
-                , Props.field
-                    { label = "Caption"
-                    , props =
-                        Props.string
-                            { value = pm.caption
-                            , onInput = (\string ps -> { ps | caption = string }) >> UpdateProgress
-                            , placeholder = ""
-                            }
-                    }
+                , Props.field "Caption"
+                    (Props.string
+                        { value = pm.caption
+                        , onInput = (\string ps -> { ps | caption = string }) >> UpdateProgress
+                        , placeholder = ""
+                        }
+                    )
                 , Props.comment "A progress element can contain a label"
                 ]
             ]
@@ -312,346 +302,322 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                 , p [] [ text "よって、われらの各自の政府は、サンフランシスコ市に会合し、全権委任状を示してそれが良好妥当であると認められた代表者を通じて、この国際連合憲章に同意したので、ここに国際連合という国際機構を設ける。" ]
                 ]
         , props =
-            [ Props.field
-                { label = "-webkit-font-smoothing"
-                , props =
-                    Props.select
-                        { value = tm.webkitFontSmoothing |> Typography.webkitFontSmoothingToString
-                        , options = [ "auto", "none", "antialiased", "subpixel-antialiased" ]
+            [ Props.field "-webkit-font-smoothing"
+                (Props.select
+                    { value = tm.webkitFontSmoothing |> Typography.webkitFontSmoothingToString
+                    , options = [ "auto", "none", "antialiased", "subpixel-antialiased" ]
+                    , onChange =
+                        (\webkitFontSmoothing m ->
+                            { m
+                                | webkitFontSmoothing =
+                                    case webkitFontSmoothing of
+                                        "auto" ->
+                                            Auto
+
+                                        "none" ->
+                                            None
+
+                                        "antialiased" ->
+                                            Antialiased
+
+                                        "subpixel-antialiased" ->
+                                            SubpixelAntialiased
+
+                                        _ ->
+                                            m.webkitFontSmoothing
+                            }
+                        )
+                            >> UpdateTypography
+                    }
+                )
+            , Props.FieldSet "Typography"
+                [ Props.field "font-family"
+                    (Props.select
+                        { value = tm.typography.font.families |> String.concat
+                        , options = [ Css.sansSerif.value, Css.serif.value ]
                         , onChange =
-                            (\webkitFontSmoothing m ->
+                            (\fontFamily m ->
                                 { m
-                                    | webkitFontSmoothing =
-                                        case webkitFontSmoothing of
-                                            "auto" ->
-                                                Auto
+                                    | typography =
+                                        case fontFamily of
+                                            "sans-serif" ->
+                                                m.typography |> Typography.setFontFamilies [ "sans-serif" ]
 
-                                            "none" ->
-                                                None
-
-                                            "antialiased" ->
-                                                Antialiased
-
-                                            "subpixel-antialiased" ->
-                                                SubpixelAntialiased
+                                            "serif" ->
+                                                m.typography |> Typography.setFontFamilies [ "serif" ]
 
                                             _ ->
-                                                m.webkitFontSmoothing
+                                                m.typography
                                 }
                             )
                                 >> UpdateTypography
                         }
-                }
-            , Props.FieldSet "Typography"
-                [ Props.field
-                    { label = "font-family"
-                    , props =
-                        Props.select
-                            { value = tm.typography.font.families |> String.concat
-                            , options = [ Css.sansSerif.value, Css.serif.value ]
-                            , onChange =
-                                (\fontFamily m ->
+                    )
+                , Props.field "font-size"
+                    (Props.counter
+                        { value = tm.fontSize
+                        , toString = \value -> String.fromFloat value ++ "px"
+                        , onClickPlus =
+                            UpdateTypography
+                                (\m ->
                                     { m
-                                        | typography =
-                                            case fontFamily of
-                                                "sans-serif" ->
-                                                    m.typography |> Typography.setFontFamilies [ "sans-serif" ]
-
-                                                "serif" ->
-                                                    m.typography |> Typography.setFontFamilies [ "serif" ]
-
-                                                _ ->
-                                                    m.typography
+                                        | fontSize = m.fontSize + 1
+                                        , typography = m.typography |> Typography.setFontSize (px (m.fontSize + 1))
                                     }
                                 )
-                                    >> UpdateTypography
-                            }
-                    }
-                , Props.field
-                    { label = "font-size"
-                    , props =
-                        Props.counter
-                            { value = tm.fontSize
-                            , toString = \value -> String.fromFloat value ++ "px"
-                            , onClickPlus =
-                                UpdateTypography
-                                    (\m ->
-                                        { m
-                                            | fontSize = m.fontSize + 1
-                                            , typography = m.typography |> Typography.setFontSize (px (m.fontSize + 1))
-                                        }
-                                    )
-                            , onClickMinus =
-                                UpdateTypography
-                                    (\m ->
-                                        { m
-                                            | fontSize = m.fontSize - 1
-                                            , typography = m.typography |> Typography.setFontSize (px (m.fontSize - 1))
-                                        }
-                                    )
-                            }
-                    }
-                , Props.field
-                    { label = "font-style"
-                    , props =
-                        Props.radio
-                            { value = tm.typography.font.style |> Maybe.map .value |> Maybe.withDefault "-"
-                            , options = [ Css.normal.value, Css.italic.value ]
-                            , onChange =
-                                (\style m ->
+                        , onClickMinus =
+                            UpdateTypography
+                                (\m ->
                                     { m
-                                        | typography =
-                                            case style of
-                                                "normal" ->
-                                                    m.typography |> Typography.setFontStyle Css.normal
-
-                                                "italic" ->
-                                                    m.typography |> Typography.setFontStyle Css.italic
-
-                                                _ ->
-                                                    m.typography
+                                        | fontSize = m.fontSize - 1
+                                        , typography = m.typography |> Typography.setFontSize (px (m.fontSize - 1))
                                     }
                                 )
-                                    >> UpdateTypography
-                            }
-                    }
-                , Props.field
-                    { label = "font-weight"
-                    , props =
-                        Props.select
-                            { value = tm.typography.font.weight |> Maybe.map .value |> Maybe.withDefault "-"
-                            , options = [ Css.lighter.value, Css.normal.value, Css.bold.value, Css.bolder.value ]
-                            , onChange =
-                                (\weight m ->
+                        }
+                    )
+                , Props.field "font-style"
+                    (Props.radio
+                        { value = tm.typography.font.style |> Maybe.map .value |> Maybe.withDefault "-"
+                        , options = [ Css.normal.value, Css.italic.value ]
+                        , onChange =
+                            (\style m ->
+                                { m
+                                    | typography =
+                                        case style of
+                                            "normal" ->
+                                                m.typography |> Typography.setFontStyle Css.normal
+
+                                            "italic" ->
+                                                m.typography |> Typography.setFontStyle Css.italic
+
+                                            _ ->
+                                                m.typography
+                                }
+                            )
+                                >> UpdateTypography
+                        }
+                    )
+                , Props.field "font-weight"
+                    (Props.select
+                        { value = tm.typography.font.weight |> Maybe.map .value |> Maybe.withDefault "-"
+                        , options = [ Css.lighter.value, Css.normal.value, Css.bold.value, Css.bolder.value ]
+                        , onChange =
+                            (\weight m ->
+                                { m
+                                    | typography =
+                                        case weight of
+                                            "lighter" ->
+                                                m.typography |> Typography.setFontWeight Css.lighter
+
+                                            "normal" ->
+                                                m.typography |> Typography.setFontWeight Css.normal
+
+                                            "bold" ->
+                                                m.typography |> Typography.setFontWeight Css.bold
+
+                                            "bolder" ->
+                                                m.typography |> Typography.setFontWeight Css.bolder
+
+                                            _ ->
+                                                m.typography
+                                }
+                            )
+                                >> UpdateTypography
+                        }
+                    )
+                , Props.field "text-align"
+                    (Props.radio
+                        { value = tm.textAlign |> Typography.textAlignToString
+                        , options = [ "left", "center", "right", "justify" ]
+                        , onChange =
+                            (\align m ->
+                                { m
+                                    | textAlign =
+                                        case align of
+                                            "left" ->
+                                                Left
+
+                                            "center" ->
+                                                Center
+
+                                            "right" ->
+                                                Right
+
+                                            "justify" ->
+                                                Justify
+
+                                            _ ->
+                                                m.textAlign
+                                    , typography =
+                                        case align of
+                                            "left" ->
+                                                m.typography |> Typography.setTextAlign Css.left
+
+                                            "center" ->
+                                                m.typography |> Typography.setTextAlign Css.center
+
+                                            "right" ->
+                                                m.typography |> Typography.setTextAlign Css.right
+
+                                            "justify" ->
+                                                m.typography |> Typography.setTextAlign Css.justify
+
+                                            _ ->
+                                                m.typography
+                                }
+                            )
+                                >> UpdateTypography
+                        }
+                    )
+                , Props.field "line-height"
+                    (Props.counter
+                        { value = tm.lineHeight
+                        , toString = \value -> String.fromFloat value
+                        , onClickPlus =
+                            UpdateTypography
+                                (\m ->
                                     { m
-                                        | typography =
-                                            case weight of
-                                                "lighter" ->
-                                                    m.typography |> Typography.setFontWeight Css.lighter
-
-                                                "normal" ->
-                                                    m.typography |> Typography.setFontWeight Css.normal
-
-                                                "bold" ->
-                                                    m.typography |> Typography.setFontWeight Css.bold
-
-                                                "bolder" ->
-                                                    m.typography |> Typography.setFontWeight Css.bolder
-
-                                                _ ->
-                                                    m.typography
+                                        | lineHeight = ((m.lineHeight * 10) + 1) / 10
+                                        , typography = m.typography |> Typography.setLineHeight (num (((m.lineHeight * 10) + 1) / 10))
                                     }
                                 )
-                                    >> UpdateTypography
-                            }
-                    }
-                , Props.field
-                    { label = "text-align"
-                    , props =
-                        Props.radio
-                            { value = tm.textAlign |> Typography.textAlignToString
-                            , options = [ "left", "center", "right", "justify" ]
-                            , onChange =
-                                (\align m ->
+                        , onClickMinus =
+                            UpdateTypography
+                                (\m ->
                                     { m
-                                        | textAlign =
-                                            case align of
-                                                "left" ->
-                                                    Left
-
-                                                "center" ->
-                                                    Center
-
-                                                "right" ->
-                                                    Right
-
-                                                "justify" ->
-                                                    Justify
-
-                                                _ ->
-                                                    m.textAlign
-                                        , typography =
-                                            case align of
-                                                "left" ->
-                                                    m.typography |> Typography.setTextAlign Css.left
-
-                                                "center" ->
-                                                    m.typography |> Typography.setTextAlign Css.center
-
-                                                "right" ->
-                                                    m.typography |> Typography.setTextAlign Css.right
-
-                                                "justify" ->
-                                                    m.typography |> Typography.setTextAlign Css.justify
-
-                                                _ ->
-                                                    m.typography
+                                        | lineHeight = ((m.lineHeight * 10) - 1) / 10
+                                        , typography = m.typography |> Typography.setLineHeight (num (((m.lineHeight * 10) - 1) / 10))
                                     }
                                 )
-                                    >> UpdateTypography
-                            }
-                    }
-                , Props.field
-                    { label = "line-height"
-                    , props =
-                        Props.counter
-                            { value = tm.lineHeight
-                            , toString = \value -> String.fromFloat value
-                            , onClickPlus =
-                                UpdateTypography
-                                    (\m ->
-                                        { m
-                                            | lineHeight = ((m.lineHeight * 10) + 1) / 10
-                                            , typography = m.typography |> Typography.setLineHeight (num (((m.lineHeight * 10) + 1) / 10))
-                                        }
-                                    )
-                            , onClickMinus =
-                                UpdateTypography
-                                    (\m ->
-                                        { m
-                                            | lineHeight = ((m.lineHeight * 10) - 1) / 10
-                                            , typography = m.typography |> Typography.setLineHeight (num (((m.lineHeight * 10) - 1) / 10))
-                                        }
-                                    )
-                            }
-                    }
-                , Props.field
-                    { label = "text-decoration"
-                    , props =
-                        Props.radio
-                            { value = tm.typography.textSetting.textDecoration |> Maybe.map .value |> Maybe.withDefault "-"
-                            , options = [ Css.none.value, Css.underline.value ]
-                            , onChange =
-                                (\decoration m ->
+                        }
+                    )
+                , Props.field "text-decoration"
+                    (Props.radio
+                        { value = tm.typography.textSetting.textDecoration |> Maybe.map .value |> Maybe.withDefault "-"
+                        , options = [ Css.none.value, Css.underline.value ]
+                        , onChange =
+                            (\decoration m ->
+                                { m
+                                    | typography =
+                                        case decoration of
+                                            "none" ->
+                                                m.typography |> Typography.setTextDecoration Css.none
+
+                                            "underline" ->
+                                                m.typography |> Typography.setTextDecoration Css.underline
+
+                                            _ ->
+                                                m.typography
+                                }
+                            )
+                                >> UpdateTypography
+                        }
+                    )
+                , Props.field "letter-spacing"
+                    (Props.counter
+                        { value = tm.letterSpacing
+                        , toString = \value -> String.fromFloat value ++ "em"
+                        , onClickPlus =
+                            UpdateTypography
+                                (\m ->
                                     { m
-                                        | typography =
-                                            case decoration of
-                                                "none" ->
-                                                    m.typography |> Typography.setTextDecoration Css.none
-
-                                                "underline" ->
-                                                    m.typography |> Typography.setTextDecoration Css.underline
-
-                                                _ ->
-                                                    m.typography
+                                        | letterSpacing = ((m.letterSpacing * 100) + 1) / 100
+                                        , typography = m.typography |> Typography.setLetterSpacing (Css.em (((m.letterSpacing * 100) + 1) / 100))
                                     }
                                 )
-                                    >> UpdateTypography
-                            }
-                    }
-                , Props.field
-                    { label = "letter-spacing"
-                    , props =
-                        Props.counter
-                            { value = tm.letterSpacing
-                            , toString = \value -> String.fromFloat value ++ "em"
-                            , onClickPlus =
-                                UpdateTypography
-                                    (\m ->
-                                        { m
-                                            | letterSpacing = ((m.letterSpacing * 100) + 1) / 100
-                                            , typography = m.typography |> Typography.setLetterSpacing (Css.em (((m.letterSpacing * 100) + 1) / 100))
-                                        }
-                                    )
-                            , onClickMinus =
-                                UpdateTypography
-                                    (\m ->
-                                        { m
-                                            | letterSpacing = ((m.letterSpacing * 100) - 1) / 100
-                                            , typography = m.typography |> Typography.setLetterSpacing (Css.em (((m.letterSpacing * 100) - 1) / 100))
-                                        }
-                                    )
-                            }
-                    }
-                , Props.field
-                    { label = "text-transform"
-                    , props =
-                        Props.select
-                            { value = tm.typography.textSetting.textTransform |> Maybe.map .value |> Maybe.withDefault "-"
-                            , options = [ Css.none.value, Css.uppercase.value, Css.lowercase.value, Css.capitalize.value ]
-                            , onChange =
-                                (\transform m ->
+                        , onClickMinus =
+                            UpdateTypography
+                                (\m ->
                                     { m
-                                        | typography =
-                                            case transform of
-                                                "none" ->
-                                                    m.typography |> Typography.setTextTransform Css.none
-
-                                                "uppercase" ->
-                                                    m.typography |> Typography.setTextTransform Css.uppercase
-
-                                                "lowercase" ->
-                                                    m.typography |> Typography.setTextTransform Css.lowercase
-
-                                                "capitalize" ->
-                                                    m.typography |> Typography.setTextTransform Css.capitalize
-
-                                                _ ->
-                                                    m.typography
+                                        | letterSpacing = ((m.letterSpacing * 100) - 1) / 100
+                                        , typography = m.typography |> Typography.setLetterSpacing (Css.em (((m.letterSpacing * 100) - 1) / 100))
                                     }
                                 )
-                                    >> UpdateTypography
-                            }
-                    }
+                        }
+                    )
+                , Props.field "text-transform"
+                    (Props.select
+                        { value = tm.typography.textSetting.textTransform |> Maybe.map .value |> Maybe.withDefault "-"
+                        , options = [ Css.none.value, Css.uppercase.value, Css.lowercase.value, Css.capitalize.value ]
+                        , onChange =
+                            (\transform m ->
+                                { m
+                                    | typography =
+                                        case transform of
+                                            "none" ->
+                                                m.typography |> Typography.setTextTransform Css.none
+
+                                            "uppercase" ->
+                                                m.typography |> Typography.setTextTransform Css.uppercase
+
+                                            "lowercase" ->
+                                                m.typography |> Typography.setTextTransform Css.lowercase
+
+                                            "capitalize" ->
+                                                m.typography |> Typography.setTextTransform Css.capitalize
+
+                                            _ ->
+                                                m.typography
+                                }
+                            )
+                                >> UpdateTypography
+                        }
+                    )
                 ]
             , Props.FieldSet "TextBlock"
-                [ Props.field
-                    { label = "word-break"
-                    , props =
-                        Props.select
-                            { value = tm.typography.textBlock.wordBreak |> Maybe.map Typography.wordBreakToString |> Maybe.withDefault "-"
-                            , options = [ "normal", "break-all", "keep-all", "auto-phrase" ]
-                            , onChange =
-                                (\wordBreak m ->
-                                    { m
-                                        | typography =
-                                            case wordBreak of
-                                                "normal" ->
-                                                    m.typography |> Typography.setWordBreak Normal_WordBreak
+                [ Props.field "word-break"
+                    (Props.select
+                        { value = tm.typography.textBlock.wordBreak |> Maybe.map Typography.wordBreakToString |> Maybe.withDefault "-"
+                        , options = [ "normal", "break-all", "keep-all", "auto-phrase" ]
+                        , onChange =
+                            (\wordBreak m ->
+                                { m
+                                    | typography =
+                                        case wordBreak of
+                                            "normal" ->
+                                                m.typography |> Typography.setWordBreak Normal_WordBreak
 
-                                                "break-all" ->
-                                                    m.typography |> Typography.setWordBreak BreakAll
+                                            "break-all" ->
+                                                m.typography |> Typography.setWordBreak BreakAll
 
-                                                "keep-all" ->
-                                                    m.typography |> Typography.setWordBreak KeepAll
+                                            "keep-all" ->
+                                                m.typography |> Typography.setWordBreak KeepAll
 
-                                                "auto-phrase" ->
-                                                    m.typography |> Typography.setWordBreak AutoPhrase
+                                            "auto-phrase" ->
+                                                m.typography |> Typography.setWordBreak AutoPhrase
 
-                                                _ ->
-                                                    m.typography
-                                    }
-                                )
-                                    >> UpdateTypography
-                            }
-                    }
-                , Props.field
-                    { label = "overflow-wrap"
-                    , props =
-                        Props.select
-                            { value = tm.typography.textBlock.overflowWrap |> Maybe.map Typography.overflowWrapToString |> Maybe.withDefault "-"
-                            , options = [ "normal", "break-word", "anywhere" ]
-                            , onChange =
-                                (\overflowWrap m ->
-                                    { m
-                                        | typography =
-                                            case overflowWrap of
-                                                "normal" ->
-                                                    m.typography |> Typography.setOverflowWrap Normal_OverflowWrap
+                                            _ ->
+                                                m.typography
+                                }
+                            )
+                                >> UpdateTypography
+                        }
+                    )
+                , Props.field "overflow-wrap"
+                    (Props.select
+                        { value = tm.typography.textBlock.overflowWrap |> Maybe.map Typography.overflowWrapToString |> Maybe.withDefault "-"
+                        , options = [ "normal", "break-word", "anywhere" ]
+                        , onChange =
+                            (\overflowWrap m ->
+                                { m
+                                    | typography =
+                                        case overflowWrap of
+                                            "normal" ->
+                                                m.typography |> Typography.setOverflowWrap Normal_OverflowWrap
 
-                                                "break-word" ->
-                                                    m.typography |> Typography.setOverflowWrap BreakWord
+                                            "break-word" ->
+                                                m.typography |> Typography.setOverflowWrap BreakWord
 
-                                                "anywhere" ->
-                                                    m.typography |> Typography.setOverflowWrap Anywhere
+                                            "anywhere" ->
+                                                m.typography |> Typography.setOverflowWrap Anywhere
 
-                                                _ ->
-                                                    m.typography
-                                    }
-                                )
-                                    >> UpdateTypography
-                            }
-                    }
+                                            _ ->
+                                                m.typography
+                                }
+                            )
+                                >> UpdateTypography
+                        }
+                    )
                 ]
             ]
         }

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -704,9 +704,6 @@ playground { isDarkMode, preview, props } =
                 , children
                     [ everything
                         [ padding (Css.em 0.75)
-                        , displayFlex
-                        , flexDirection column
-                        , rowGap (Css.em 0.5)
                         , borderRadius (Css.em 0.5)
                         , palette (Palette.propsField isDarkMode)
                         ]

--- a/package/src/DesignToken/Palette.elm
+++ b/package/src/DesignToken/Palette.elm
@@ -15,7 +15,7 @@ module DesignToken.Palette exposing
 
 -}
 
-import Css exposing (Style, hover)
+import Css exposing (Color, Style, hover, rgba)
 import Css.Color exposing (Hsl360, hsla)
 import Css.Palette exposing (Palette, init, setBackground, setColor)
 import Css.Palette.Extra exposing (light_dark)
@@ -130,9 +130,12 @@ propsField isDarkMode =
         }
 
 
-formField : Palette Hsl360
+formField : Palette Color
 formField =
-    { light | background = Just (hsla 0 0 0 0) }
+    { background = Just (rgba 0 0 0 0)
+    , color = Just (rgba 0 0 0 0.87)
+    , border = Just (rgba 34 36 38 0.15)
+    }
 
 
 

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -348,105 +348,34 @@ toggleInput : List (Attribute msg) -> List (Html msg) -> Html msg
 toggleInput =
     Html.styled Html.input
         [ cursor pointer
+        , width (rem 3.5)
+        , height (rem 1.5)
         , opacity zero
-        , active
-            [ generalSiblings
-                [ Css.Global.label
-                    [ -- .ui.checkbox input:active ~ label
-                      color (rgba 0 0 0 0.95)
-                    ]
-                ]
-            ]
         , focus
             [ generalSiblings
                 [ Css.Global.label
-                    [ -- .ui.checkbox input:focus ~ label
-                      color (rgba 0 0 0 0.95)
-
-                    -- .ui.checkbox input:focus ~ label:before
-                    , before
-                        [ palette
-                            (Palette.init
-                                |> setBackground (hex "#FFFFFF")
-                                |> setBorder (hex "#96C8DA")
-                            )
-                        ]
-
-                    -- .ui.checkbox input:focus ~ label:after
-                    , after
-                        [ color (rgba 0 0 0 0.95) ]
-                    ]
+                    [ before [ palette (Palette.init |> setBackground (rgba 0 0 0 0.15)) ] ]
                 ]
             ]
         , checked
-            [ generalSiblings
-                [ Css.Global.label
-                    [ -- .ui.checkbox input:checked ~ label:before
-                      before
-                        [ palette
-                            (Palette.init
-                                |> setBackground (hex "#FFFFFF")
-                                |> setBorder (rgba 34 36 38 0.35)
-                            )
-                        ]
-
-                    -- .ui.checkbox input:checked ~ label:after
-                    , after
-                        [ opacity (int 1)
-                        , color (rgba 0 0 0 0.95)
-                        ]
-
-                    -- .ui.checkbox input:checked ~ .box:after
-                    -- .ui.checkbox input:checked ~ label:after
-                    , after
-                        [ property "content" "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='black' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e\")" ]
-                    ]
-                ]
-            ]
-        , -- .ui.toggle.checkbox input
-          width (rem 3.5)
-        , height (rem 1.5)
-
-        -- .ui.toggle.checkbox input:focus ~ label:before
-        , focus
             [ generalSiblings
                 [ Css.Global.label
                     [ before
-                        [ backgroundColor (rgba 0 0 0 0.15)
-                        , property "border" "none"
+                        [ palette
+                            (Palette.init
+                                |> setBackground (hex "#2185D0")
+                                |> setBorder (rgba 34 36 38 0.35)
+                            )
                         ]
-                    ]
-                ]
-            ]
-
-        -- .ui.toggle.checkbox input:checked ~ label
-        , checked
-            [ generalSiblings
-                [ Css.Global.label
-                    [ color (rgba 0 0 0 0.95) |> important
-
-                    -- .ui.toggle.checkbox input:checked ~ label:before
-                    , before
-                        [ backgroundColor (hex "#2185D0") |> important ]
-
-                    -- .ui.toggle.checkbox input:checked ~ label:after
                     , after
-                        [ left (rem 2.15)
-                        , property "-webkit-box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
-                        , property "box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
-                        ]
+                        [ left (rem 2.15) ]
                     ]
                 ]
-
-            -- .ui.toggle.checkbox input:focus:checked ~ label
             , focus
                 [ generalSiblings
                     [ Css.Global.label
-                        [ color (rgba 0 0 0 0.95) |> important
-
-                        -- .ui.toggle.checkbox input:focus:checked ~ label:before
-                        , before
-                            [ backgroundColor (hex "#0d71bb") |> important ]
+                        [ before
+                            [ backgroundColor (hex "#0d71bb") ]
                         ]
                     ]
                 ]
@@ -457,121 +386,54 @@ toggleInput =
 toggleLabel : List (Attribute msg) -> List (Html msg) -> Html msg
 toggleLabel =
     Html.styled Html.label
-        [ -- .ui.checkbox label
-          position relative
+        [ position relative
         , outline none
-
-        -- .ui.checkbox label:before
         , before
             [ position absolute
             , top zero
             , left zero
+            , zIndex (int 1)
             , property "content" "''"
-            , borderRadius (rem 0.21428571)
+            , display block
+            , width (rem 3.5)
+            , height (rem 1.5)
+            , borderRadius (rem 500)
             , property "-webkit-transition" "border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease"
             , property "transition" "border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease"
             , property "transition" "border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease"
             , property "transition" "border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease"
-            , paletteWithBorder (border3 (px 1) solid)
+            , palette
                 (Palette.init
-                    |> setBackground (hex "#FFFFFF")
+                    |> setBackground (rgba 0 0 0 0.05)
                     |> setBorder (hex "#D4D4D5")
                 )
             ]
-
-        -- .ui.checkbox label:after
         , after
             [ position absolute
-            , fontSize (px 14)
             , top zero
-            , left zero
-            , textAlign center
-            , opacity zero
-            , color (rgba 0 0 0 0.87)
-            , property "-webkit-transition" "border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;"
-            , property "transition" "border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;"
-            , property "transition" "border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease;"
-            , property "transition" "border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;"
-            ]
-
-        -- Hover
-        , hover
-            [ -- .ui.checkbox label:hover::before
-              before
-                [ palette
-                    (Palette.init
-                        |> setBackground (hex "#FFFFFF")
-                        |> setBorder (rgba 34 36 38 0.35)
-                    )
-                ]
-            ]
-
-        -- Down
-        , active
-            [ -- .ui.checkbox label:active::before
-              before
-                [ palette
-                    (Palette.init
-                        |> setBackground (hex "#F9FAFB")
-                        |> setBorder (rgba 34 36 38 0.35)
-                    )
-                ]
-
-            -- .ui.checkbox label:active::after
-            , after
-                [ color (rgba 0 0 0 0.95) ]
-            ]
-
-        -- .ui.toggle.checkbox label:before
-        , before
-            [ display block
-            , position absolute
-            , property "content" "''"
-            , zIndex (int 1)
-            , property "-webkit-transform" "none"
-            , property "transform" "none"
-            , property "border" "none"
-            , top zero
-            , backgroundColor (rgba 0 0 0 0.05)
-            , property "-webkit-box-shadow" "none"
-            , property "box-shadow" "none"
-            , width (rem 3.5)
-            , height (rem 1.5)
-            , borderRadius (rem 500)
-            ]
-
-        -- .ui.toggle.checkbox label:after
-        , after
-            [ property "background" "#FFFFFF -webkit-gradient(linear, left top, left bottom, from(transparent), to(rgba(0, 0, 0, 0.05)))"
-            , property "background" "#FFFFFF -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.05))"
-            , property "background" "#FFFFFF linear-gradient(transparent, rgba(0, 0, 0, 0.05))"
-            , position absolute
-            , property "content" "''" |> important
-            , opacity (int 1)
+            , left (rem -0.05)
             , zIndex (int 2)
-            , property "border" "none"
-            , property "-webkit-box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
-            , property "box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
+            , property "content" "''"
             , width (rem 1.5)
             , height (rem 1.5)
-            , top zero
-            , left zero
             , borderRadius (rem 500)
             , property "-webkit-transition" "background 0.3s ease, left 0.3s ease"
             , property "transition" "background 0.3s ease, left 0.3s ease"
-
-            -- .ui.toggle.checkbox input ~ label:after
-            , left (rem -0.05)
+            , property "background" "#FFFFFF -webkit-gradient(linear, left top, left bottom, from(transparent), to(rgba(0, 0, 0, 0.05)))"
+            , property "background" "#FFFFFF -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.05))"
+            , property "background" "#FFFFFF linear-gradient(transparent, rgba(0, 0, 0, 0.05))"
             , property "-webkit-box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
             , property "box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
             ]
-
-        -- .ui.toggle.checkbox label:hover::before {
+        , active
+            [ before
+                [ palette (Palette.init |> setBackground (hex "#F9FAFB")) ]
+            , after
+                [ color (rgba 0 0 0 0.95) ]
+            ]
         , hover
             [ before
-                [ backgroundColor (rgba 0 0 0 0.15)
-                , property "border" "none"
-                ]
+                [ palette (Palette.init |> setBackground (rgba 0 0 0 0.15)) ]
             ]
         ]
 

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -189,7 +189,7 @@ render props =
                 ]
 
         List childProps ->
-            div [ css [ displayFlex, flexDirection column, rowGap (Css.em 0.5) ] ]
+            div [ css [ displayFlex, flexDirection column, rowGap (Css.em 1) ] ]
                 (List.map render childProps)
 
         FieldSet label childProps ->
@@ -197,7 +197,7 @@ render props =
                 [ css
                     [ displayFlex
                     , flexDirection column
-                    , rowGap (Css.em 0.5)
+                    , rowGap (Css.em 1)
                     , borderWidth zero
                     ]
                 ]

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -98,6 +98,7 @@ render props =
                 , placeholder ps.placeholder
                 , css
                     [ property "appearance" "none"
+                    , width (pct 100)
                     , padding (em 0.75)
                     , fontSize inherit
                     , borderRadius (em 0.25)
@@ -117,6 +118,7 @@ render props =
                 [ onInput ps.onChange
                 , css
                     [ property "appearance" "none"
+                    , width (pct 100)
                     , padding (em 0.75)
                     , fontSize inherit
                     , borderRadius (em 0.25)
@@ -198,13 +200,13 @@ render props =
             div
                 [ css
                     [ displayFlex
-                    , flexDirection column
+                    , flexWrap wrap
                     , rowGap (em 0.25)
                     ]
                 ]
-                [ div [] [ Html.label [ css [ fontWeight bold ] ] [ text label ] ]
-                , render ps
-                , div [ css [ palette Palette.textOptional ] ] [ text note ]
+                [ Html.label [ css [ width (pct 50) ] ] [ text label ]
+                , div [ css [ width (pct 50) ] ] [ render ps ]
+                , div [ css [ width (pct 100), palette Palette.textOptional, empty [ display none ] ] ] [ text note ]
                 ]
 
         Customize view ->

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -21,7 +21,7 @@ module Emaki.Props exposing
 -}
 
 import Css exposing (..)
-import Css.Extra exposing (grid, rowGap)
+import Css.Extra exposing (grid, gridColumn, gridRow, rowGap)
 import Css.Global exposing (children, selector, typeSelector)
 import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setColor)
 import Css.Palette.Extra exposing (paletteByState)
@@ -162,8 +162,17 @@ render props =
                     , width (pct 100)
                     , padding (em 0.75)
                     , fontSize inherit
+                    , lineHeight (em 1)
                     , borderRadius (em 0.25)
                     , paletteWithBorder (border3 (px 1) solid) Palette.formField
+                    , focus
+                        [ palette
+                            { background = Nothing
+                            , color = Just (rgba 0 0 0 0.95)
+                            , border = Just (hex "#85b7d9")
+                            }
+                        , outline none
+                        ]
                     ]
                 ]
                 []
@@ -175,20 +184,46 @@ render props =
                 ]
 
         Select ps ->
-            Html.select
-                [ onInput ps.onChange
-                , css
-                    [ property "appearance" "none"
-                    , width (pct 100)
-                    , padding (em 0.75)
-                    , fontSize inherit
-                    , borderRadius (em 0.25)
-                    , paletteWithBorder (border3 (px 1) solid) Palette.formField
+            Html.div
+                [ css
+                    [ display grid
+                    , property "grid-template-columns" "1fr auto"
+                    , alignItems center
+                    , before
+                        [ property "content" (qt "▼")
+                        , gridColumn "2"
+                        , gridRow "1"
+                        , padding (em 1)
+                        , fontSize (em 0.6)
+                        ]
                     ]
                 ]
-                (List.map (\option -> Html.option [ value option, selected (ps.value == option) ] [ text option ])
-                    ps.options
-                )
+                [ Html.select
+                    [ onInput ps.onChange
+                    , css
+                        [ gridColumn "1 / -1"
+                        , gridRow "1"
+                        , property "appearance" "none"
+                        , width (pct 100)
+                        , padding (em 0.75)
+                        , fontSize inherit
+                        , lineHeight (em 1)
+                        , borderRadius (em 0.25)
+                        , paletteWithBorder (border3 (px 1) solid) Palette.formField
+                        , focus
+                            [ palette
+                                { background = Nothing
+                                , color = Just (rgba 0 0 0 0.95)
+                                , border = Just (hex "#85b7d9")
+                                }
+                            , outline none
+                            ]
+                        ]
+                    ]
+                    (List.map (\option -> Html.option [ value option, selected (ps.value == option) ] [ text option ])
+                        ps.options
+                    )
+                ]
 
         Radio ps ->
             Html.div []

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -298,7 +298,6 @@ labeledButtons attributes =
                     [ displayFlex
                     , alignItems center
                     , justifyContent center
-                    , margin4 zero zero zero (px -1)
                     , fontSize (em 1)
                     , borderColor (rgba 34 36 38 0.15)
 

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -153,7 +153,13 @@ render : Props msg -> Html msg
 render props =
     case props of
         Comment str ->
-            Html.div [ css [ palette Palette.textOptional ] ] [ text str ]
+            Html.div
+                [ css
+                    [ palette Palette.textOptional
+                    , empty [ display none ]
+                    ]
+                ]
+                [ text str ]
 
         String ps ->
             input

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -53,7 +53,7 @@ type alias StringProps msg =
 
 
 type alias BoolProps msg =
-    { label : String
+    { id : String
     , value : Bool
     , onClick : msg
     }
@@ -189,8 +189,7 @@ render props =
 
         Bool ps ->
             toggleCheckbox
-                { id = ps.label
-                , label = ps.label
+                { id = ps.id
                 , checked = ps.value
                 , onClick = ps.onClick
                 }
@@ -324,7 +323,6 @@ render props =
 
 toggleCheckbox :
     { id : String
-    , label : String
     , checked : Bool
     , onClick : msg
     }
@@ -342,7 +340,7 @@ toggleCheckbox props =
             , onClick props.onClick
             ]
             []
-        , toggleLabel [ for props.id ] [ text props.label ]
+        , toggleLabel [ for props.id ] []
         ]
 
 
@@ -461,8 +459,6 @@ toggleLabel =
     Html.styled Html.label
         [ -- .ui.checkbox label
           position relative
-        , display block
-        , paddingLeft (em 1.85714)
         , outline none
 
         -- .ui.checkbox label:before
@@ -508,10 +504,6 @@ toggleLabel =
                         |> setBorder (rgba 34 36 38 0.35)
                     )
                 ]
-
-            -- .ui.checkbox label:hover
-            -- .ui.checkbox + label:hover
-            , color (rgba 0 0 0 0.8)
             ]
 
         -- Down
@@ -529,21 +521,6 @@ toggleLabel =
             , after
                 [ color (rgba 0 0 0 0.95) ]
             ]
-
-        -- .ui.checkbox input.hidden + label
-        , cursor pointer
-        , property "-webkit-user-select" "none"
-        , property "-moz-user-select" "none"
-        , property "-ms-user-select" "none"
-        , property "user-select" "none"
-
-        -- .ui.toggle.checkbox label
-        , minHeight (rem 1.5)
-        , paddingLeft (rem 4.5)
-        , color (rgba 0 0 0 0.87)
-
-        -- .ui.toggle.checkbox label
-        , paddingTop (em 0.15)
 
         -- .ui.toggle.checkbox label:before
         , before

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -41,7 +41,7 @@ type Props msg
     | BoolAndString (BoolAndStringProps msg)
     | List (List (Props msg))
     | FieldSet String (List (Props msg))
-    | Field { label : String } (Props msg)
+    | Field String (Props msg)
     | Customize (Html msg)
 
 
@@ -135,13 +135,9 @@ fieldset =
     FieldSet
 
 
-field :
-    { label : String
-    , props : Props msg
-    }
-    -> Props msg
-field { label, props } =
-    Field { label = label } props
+field : String -> Props msg -> Props msg
+field label props =
+    Field label props
 
 
 customize : Html msg -> Props msg
@@ -298,7 +294,7 @@ render props =
                 legend [ css [ fontWeight bold ] ] [ text label ]
                     :: List.map render childProps
 
-        Field { label } ps ->
+        Field label ps ->
             div
                 [ css
                     [ display grid

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -2,7 +2,7 @@ module Emaki.Props exposing
     ( Props(..)
     , StringProps, BoolProps, SelectProps, RadioProps, CounterProps, BoolAndStringProps
     , render
-    , string, bool, select, radio, counter, boolAndString
+    , comment, string, bool, select, radio, counter, boolAndString
     , list, fieldset
     , field
     , customize
@@ -13,7 +13,7 @@ module Emaki.Props exposing
 @docs Props
 @docs StringProps, BoolProps, SelectProps, RadioProps, CounterProps, BoolAndStringProps
 @docs render
-@docs string, bool, select, radio, counter, boolAndString
+@docs comment, string, bool, select, radio, counter, boolAndString
 @docs list, fieldset
 @docs field
 @docs customize
@@ -21,7 +21,7 @@ module Emaki.Props exposing
 -}
 
 import Css exposing (..)
-import Css.Extra exposing (grid, gridColumn, gridRow, rowGap)
+import Css.Extra exposing (fr, grid, gridColumn, gridRow, gridTemplateColumns, rowGap)
 import Css.Global exposing (children, selector, typeSelector)
 import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setColor)
 import Css.Palette.Extra exposing (paletteByState)
@@ -32,7 +32,8 @@ import Html.Styled.Events exposing (onClick, onInput)
 
 
 type Props msg
-    = String (StringProps msg)
+    = Comment String
+    | String (StringProps msg)
     | Bool (BoolProps msg)
     | Select (SelectProps msg)
     | Radio (RadioProps msg)
@@ -40,7 +41,7 @@ type Props msg
     | BoolAndString (BoolAndStringProps msg)
     | List (List (Props msg))
     | FieldSet String (List (Props msg))
-    | Field { label : String, note : String } (Props msg)
+    | Field { label : String } (Props msg)
     | Customize (Html msg)
 
 
@@ -89,6 +90,11 @@ type alias BoolAndStringProps msg =
     }
 
 
+comment : String -> Props msg
+comment =
+    Comment
+
+
 string : StringProps msg -> Props msg
 string =
     String
@@ -132,11 +138,10 @@ fieldset =
 field :
     { label : String
     , props : Props msg
-    , note : String
     }
     -> Props msg
-field { label, note, props } =
-    Field { label = label, note = note } props
+field { label, props } =
+    Field { label = label } props
 
 
 customize : Html msg -> Props msg
@@ -151,6 +156,9 @@ customize =
 render : Props msg -> Html msg
 render props =
     case props of
+        Comment str ->
+            Html.div [ css [ palette Palette.textOptional ] ] [ text str ]
+
         String ps ->
             input
                 [ type_ "text"
@@ -290,17 +298,16 @@ render props =
                 legend [ css [ fontWeight bold ] ] [ text label ]
                     :: List.map render childProps
 
-        Field { label, note } ps ->
+        Field { label } ps ->
             div
                 [ css
-                    [ displayFlex
-                    , flexWrap wrap
-                    , rowGap (em 0.25)
+                    [ display grid
+                    , gridTemplateColumns [ fr 1, fr 1 ]
+                    , alignItems center
                     ]
                 ]
-                [ Html.label [ css [ width (pct 50) ] ] [ text label ]
-                , div [ css [ width (pct 50) ] ] [ render ps ]
-                , div [ css [ width (pct 100), palette Palette.textOptional, empty [ display none ] ] ] [ text note ]
+                [ Html.label [] [ text label ]
+                , render ps
                 ]
 
         Customize view ->

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -189,10 +189,19 @@ render props =
                 ]
 
         List childProps ->
-            div [] (List.map render childProps)
+            div [ css [ displayFlex, flexDirection column, rowGap (Css.em 0.5) ] ]
+                (List.map render childProps)
 
         FieldSet label childProps ->
-            Html.div [ css [ borderWidth zero ] ] <|
+            Html.div
+                [ css
+                    [ displayFlex
+                    , flexDirection column
+                    , rowGap (Css.em 0.5)
+                    , borderWidth zero
+                    ]
+                ]
+            <|
                 legend [ css [ fontWeight bold ] ] [ text label ]
                     :: List.map render childProps
 

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -22,12 +22,12 @@ module Emaki.Props exposing
 
 import Css exposing (..)
 import Css.Extra exposing (fr, grid, gridColumn, gridRow, gridTemplateColumns, rowGap)
-import Css.Global exposing (children, selector, typeSelector)
-import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setColor)
+import Css.Global exposing (children, everything, generalSiblings, selector, typeSelector)
+import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setBorder, setColor)
 import Css.Palette.Extra exposing (paletteByState)
 import DesignToken.Palette as Palette
 import Html.Styled as Html exposing (Attribute, Html, div, input, legend, text)
-import Html.Styled.Attributes as Attributes exposing (css, placeholder, selected, type_, value)
+import Html.Styled.Attributes as Attributes exposing (css, for, id, placeholder, selected, type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
 
 
@@ -188,10 +188,12 @@ render props =
                 []
 
         Bool ps ->
-            Html.label []
-                [ input [ type_ "checkbox", Attributes.checked ps.value, onClick ps.onClick ] []
-                , text ps.label
-                ]
+            toggleCheckbox
+                { id = ps.label
+                , label = ps.label
+                , checked = ps.value
+                , onClick = ps.onClick
+                }
 
         Select ps ->
             Html.div
@@ -318,6 +320,283 @@ render props =
 
 
 -- VIEW HELPERS
+
+
+toggleCheckbox :
+    { id : String
+    , label : String
+    , checked : Bool
+    , onClick : msg
+    }
+    -> Html msg
+toggleCheckbox props =
+    Html.styled Html.div
+        [ display grid
+        , children [ everything [ gridColumn "1", gridRow "1" ] ]
+        ]
+        []
+        [ toggleInput
+            [ id props.id
+            , type_ "checkbox"
+            , Attributes.checked props.checked
+            , onClick props.onClick
+            ]
+            []
+        , toggleLabel [ for props.id ] [ text props.label ]
+        ]
+
+
+toggleInput : List (Attribute msg) -> List (Html msg) -> Html msg
+toggleInput =
+    Html.styled Html.input
+        [ cursor pointer
+        , opacity zero
+        , active
+            [ generalSiblings
+                [ Css.Global.label
+                    [ -- .ui.checkbox input:active ~ label
+                      color (rgba 0 0 0 0.95)
+                    ]
+                ]
+            ]
+        , focus
+            [ generalSiblings
+                [ Css.Global.label
+                    [ -- .ui.checkbox input:focus ~ label
+                      color (rgba 0 0 0 0.95)
+
+                    -- .ui.checkbox input:focus ~ label:before
+                    , before
+                        [ palette
+                            (Palette.init
+                                |> setBackground (hex "#FFFFFF")
+                                |> setBorder (hex "#96C8DA")
+                            )
+                        ]
+
+                    -- .ui.checkbox input:focus ~ label:after
+                    , after
+                        [ color (rgba 0 0 0 0.95) ]
+                    ]
+                ]
+            ]
+        , checked
+            [ generalSiblings
+                [ Css.Global.label
+                    [ -- .ui.checkbox input:checked ~ label:before
+                      before
+                        [ palette
+                            (Palette.init
+                                |> setBackground (hex "#FFFFFF")
+                                |> setBorder (rgba 34 36 38 0.35)
+                            )
+                        ]
+
+                    -- .ui.checkbox input:checked ~ label:after
+                    , after
+                        [ opacity (int 1)
+                        , color (rgba 0 0 0 0.95)
+                        ]
+
+                    -- .ui.checkbox input:checked ~ .box:after
+                    -- .ui.checkbox input:checked ~ label:after
+                    , after
+                        [ property "content" "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='black' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e\")" ]
+                    ]
+                ]
+            ]
+        , -- .ui.toggle.checkbox input
+          width (rem 3.5)
+        , height (rem 1.5)
+
+        -- .ui.toggle.checkbox input:focus ~ label:before
+        , focus
+            [ generalSiblings
+                [ Css.Global.label
+                    [ before
+                        [ backgroundColor (rgba 0 0 0 0.15)
+                        , property "border" "none"
+                        ]
+                    ]
+                ]
+            ]
+
+        -- .ui.toggle.checkbox input:checked ~ label
+        , checked
+            [ generalSiblings
+                [ Css.Global.label
+                    [ color (rgba 0 0 0 0.95) |> important
+
+                    -- .ui.toggle.checkbox input:checked ~ label:before
+                    , before
+                        [ backgroundColor (hex "#2185D0") |> important ]
+
+                    -- .ui.toggle.checkbox input:checked ~ label:after
+                    , after
+                        [ left (rem 2.15)
+                        , property "-webkit-box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
+                        , property "box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
+                        ]
+                    ]
+                ]
+
+            -- .ui.toggle.checkbox input:focus:checked ~ label
+            , focus
+                [ generalSiblings
+                    [ Css.Global.label
+                        [ color (rgba 0 0 0 0.95) |> important
+
+                        -- .ui.toggle.checkbox input:focus:checked ~ label:before
+                        , before
+                            [ backgroundColor (hex "#0d71bb") |> important ]
+                        ]
+                    ]
+                ]
+            ]
+        ]
+
+
+toggleLabel : List (Attribute msg) -> List (Html msg) -> Html msg
+toggleLabel =
+    Html.styled Html.label
+        [ -- .ui.checkbox label
+          position relative
+        , display block
+        , paddingLeft (em 1.85714)
+        , outline none
+
+        -- .ui.checkbox label:before
+        , before
+            [ position absolute
+            , top zero
+            , left zero
+            , property "content" "''"
+            , borderRadius (rem 0.21428571)
+            , property "-webkit-transition" "border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease"
+            , property "transition" "border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease"
+            , property "transition" "border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease"
+            , property "transition" "border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease"
+            , paletteWithBorder (border3 (px 1) solid)
+                (Palette.init
+                    |> setBackground (hex "#FFFFFF")
+                    |> setBorder (hex "#D4D4D5")
+                )
+            ]
+
+        -- .ui.checkbox label:after
+        , after
+            [ position absolute
+            , fontSize (px 14)
+            , top zero
+            , left zero
+            , textAlign center
+            , opacity zero
+            , color (rgba 0 0 0 0.87)
+            , property "-webkit-transition" "border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;"
+            , property "transition" "border 0.1s ease, opacity 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;"
+            , property "transition" "border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease;"
+            , property "transition" "border 0.1s ease, opacity 0.1s ease, transform 0.1s ease, box-shadow 0.1s ease, -webkit-transform 0.1s ease, -webkit-box-shadow 0.1s ease;"
+            ]
+
+        -- Hover
+        , hover
+            [ -- .ui.checkbox label:hover::before
+              before
+                [ palette
+                    (Palette.init
+                        |> setBackground (hex "#FFFFFF")
+                        |> setBorder (rgba 34 36 38 0.35)
+                    )
+                ]
+
+            -- .ui.checkbox label:hover
+            -- .ui.checkbox + label:hover
+            , color (rgba 0 0 0 0.8)
+            ]
+
+        -- Down
+        , active
+            [ -- .ui.checkbox label:active::before
+              before
+                [ palette
+                    (Palette.init
+                        |> setBackground (hex "#F9FAFB")
+                        |> setBorder (rgba 34 36 38 0.35)
+                    )
+                ]
+
+            -- .ui.checkbox label:active::after
+            , after
+                [ color (rgba 0 0 0 0.95) ]
+            ]
+
+        -- .ui.checkbox input.hidden + label
+        , cursor pointer
+        , property "-webkit-user-select" "none"
+        , property "-moz-user-select" "none"
+        , property "-ms-user-select" "none"
+        , property "user-select" "none"
+
+        -- .ui.toggle.checkbox label
+        , minHeight (rem 1.5)
+        , paddingLeft (rem 4.5)
+        , color (rgba 0 0 0 0.87)
+
+        -- .ui.toggle.checkbox label
+        , paddingTop (em 0.15)
+
+        -- .ui.toggle.checkbox label:before
+        , before
+            [ display block
+            , position absolute
+            , property "content" "''"
+            , zIndex (int 1)
+            , property "-webkit-transform" "none"
+            , property "transform" "none"
+            , property "border" "none"
+            , top zero
+            , backgroundColor (rgba 0 0 0 0.05)
+            , property "-webkit-box-shadow" "none"
+            , property "box-shadow" "none"
+            , width (rem 3.5)
+            , height (rem 1.5)
+            , borderRadius (rem 500)
+            ]
+
+        -- .ui.toggle.checkbox label:after
+        , after
+            [ property "background" "#FFFFFF -webkit-gradient(linear, left top, left bottom, from(transparent), to(rgba(0, 0, 0, 0.05)))"
+            , property "background" "#FFFFFF -webkit-linear-gradient(transparent, rgba(0, 0, 0, 0.05))"
+            , property "background" "#FFFFFF linear-gradient(transparent, rgba(0, 0, 0, 0.05))"
+            , position absolute
+            , property "content" "''" |> important
+            , opacity (int 1)
+            , zIndex (int 2)
+            , property "border" "none"
+            , property "-webkit-box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
+            , property "box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
+            , width (rem 1.5)
+            , height (rem 1.5)
+            , top zero
+            , left zero
+            , borderRadius (rem 500)
+            , property "-webkit-transition" "background 0.3s ease, left 0.3s ease"
+            , property "transition" "background 0.3s ease, left 0.3s ease"
+
+            -- .ui.toggle.checkbox input ~ label:after
+            , left (rem -0.05)
+            , property "-webkit-box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
+            , property "box-shadow" "0 1px 2px 0 rgba(34, 36, 38, 0.15), 0 0 0 1px rgba(34, 36, 38, 0.15) inset"
+            ]
+
+        -- .ui.toggle.checkbox label:hover::before {
+        , hover
+            [ before
+                [ backgroundColor (rgba 0 0 0 0.15)
+                , property "border" "none"
+                ]
+            ]
+        ]
 
 
 labeledButtons : List (Attribute msg) -> List (Html msg) -> Html msg

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -21,10 +21,12 @@ module Emaki.Props exposing
 -}
 
 import Css exposing (..)
-import Css.Extra exposing (columnGap, rowGap)
-import Css.Palette exposing (palette, paletteWithBorder)
+import Css.Extra exposing (grid, rowGap)
+import Css.Global exposing (children, selector, typeSelector)
+import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setColor)
+import Css.Palette.Extra exposing (paletteByState)
 import DesignToken.Palette as Palette
-import Html.Styled as Html exposing (Html, button, div, input, legend, text)
+import Html.Styled as Html exposing (Attribute, Html, div, input, legend, text)
 import Html.Styled.Attributes as Attributes exposing (css, placeholder, selected, type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
 
@@ -148,20 +150,9 @@ render props =
                 )
 
         Counter ps ->
-            let
-                button_ attributes =
-                    button
-                        (css
-                            [ padding2 (em 0.25) (em 0.5)
-                            , borderRadius (em 0.25)
-                            , paletteWithBorder (border3 (px 1) solid) Palette.formField
-                            ]
-                            :: attributes
-                        )
-            in
-            div [ css [ displayFlex, alignItems center, columnGap (em 0.5) ] ]
+            labeledButtons []
                 [ button_ [ onClick ps.onClickMinus ] [ text "-" ]
-                , text (ps.toString ps.value)
+                , basicLabel [] [ text (ps.toString ps.value) ]
                 , button_ [ onClick ps.onClickPlus ] [ text "+" ]
                 ]
 
@@ -275,3 +266,99 @@ field { label, note, props } =
 customize : Html msg -> Props msg
 customize =
     Customize
+
+
+
+-- VIEW HELPERS
+
+
+labeledButtons : List (Attribute msg) -> List (Html msg) -> Html msg
+labeledButtons attributes =
+    Html.div <|
+        css
+            [ cursor pointer
+            , display grid
+            , property "grid-template-columns" "auto 1fr auto"
+            , children
+                [ typeSelector "button"
+                    [ firstChild
+                        [ borderTopRightRadius zero
+                        , borderBottomRightRadius zero
+                        ]
+                    , lastChild
+                        [ borderTopLeftRadius zero
+                        , borderBottomLeftRadius zero
+                        ]
+                    ]
+                , selector "*:not(button)"
+                    [ displayFlex
+                    , alignItems center
+                    , justifyContent center
+                    , margin4 zero zero zero (px -1)
+                    , fontSize (em 1)
+                    , borderColor (rgba 34 36 38 0.15)
+
+                    -- Extra Styles
+                    , borderRadius zero
+                    ]
+                ]
+            ]
+            :: attributes
+
+
+button_ : List (Attribute msg) -> List (Html msg) -> Html msg
+button_ =
+    Html.styled Html.button
+        [ cursor pointer
+        , minHeight (em 1)
+        , outline none
+        , borderStyle none
+        , textAlign center
+        , lineHeight (em 1)
+        , fontWeight bold
+        , padding2 (em 0.75) (em 1.5)
+        , borderRadius (em 0.25)
+        , property "user-select" "none"
+        , paletteByState defaultPalettes
+        , disabled
+            [ cursor default
+            , opacity (num 0.45)
+            , backgroundImage none
+            , pointerEvents none
+            ]
+        ]
+
+
+defaultPalettes : ( Palette (ColorValue Color), List ( List Style -> Style, Palette (ColorValue Color) ) )
+defaultPalettes =
+    let
+        default =
+            { background = Just (hex "#E0E1E2")
+            , color = Just (rgba 0 0 0 0.6)
+            , border = Nothing
+            }
+    in
+    ( default
+    , [ ( hover, default |> setBackground (hex "#CACBCD") |> setColor (rgba 0 0 0 0.8) )
+      , ( focus, default |> setBackground (hex "#CACBCD") |> setColor (rgba 0 0 0 0.8) )
+      , ( active, default |> setBackground (hex "#BABBBC") |> setColor (rgba 0 0 0 0.9) )
+      ]
+    )
+
+
+basicLabel : List (Attribute msg) -> List (Html msg) -> Html msg
+basicLabel =
+    Html.styled Html.div
+        [ display inlineBlock
+        , fontSize (rem 0.85714286)
+        , lineHeight (num 1)
+        , palette
+            { background = Nothing
+            , color = Just (rgba 0 0 0 0.87)
+            , border = Nothing
+            }
+        , border3 (px 1) solid (rgba 34 36 38 0.15)
+        , borderRadius (rem 0.25)
+        , property "-webkit-transition" "background 0.1s ease"
+        , property "transition" "background 0.1s ease"
+        ]

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -297,7 +297,7 @@ render props =
                     ]
                 ]
             <|
-                legend [ css [ fontWeight bold ] ] [ text label ]
+                legend [ css [ fontWeight bold, empty [ display none ] ] ] [ text label ]
                     :: List.map render childProps
 
         Field label ps ->

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -298,7 +298,7 @@ render props =
                     ]
                 ]
             <|
-                legend [ css [ fontWeight bold, empty [ display none ] ] ] [ text label ]
+                legend [ css [ padding zero, fontWeight bold, empty [ display none ] ] ] [ text label ]
                     :: List.map render childProps
 
         Field label ps ->

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -89,6 +89,65 @@ type alias BoolAndStringProps msg =
     }
 
 
+string : StringProps msg -> Props msg
+string =
+    String
+
+
+bool : BoolProps msg -> Props msg
+bool =
+    Bool
+
+
+select : SelectProps msg -> Props msg
+select =
+    Select
+
+
+radio : RadioProps msg -> Props msg
+radio =
+    Radio
+
+
+counter : CounterProps msg -> Props msg
+counter =
+    Counter
+
+
+boolAndString : BoolAndStringProps msg -> Props msg
+boolAndString =
+    BoolAndString
+
+
+list : List (Props msg) -> Props msg
+list =
+    List
+
+
+fieldset : String -> List (Props msg) -> Props msg
+fieldset =
+    FieldSet
+
+
+field :
+    { label : String
+    , props : Props msg
+    , note : String
+    }
+    -> Props msg
+field { label, note, props } =
+    Field { label = label, note = note } props
+
+
+customize : Html msg -> Props msg
+customize =
+    Customize
+
+
+
+-- VIEW
+
+
 render : Props msg -> Html msg
 render props =
     case props of
@@ -211,61 +270,6 @@ render props =
 
         Customize view ->
             view
-
-
-string : StringProps msg -> Props msg
-string =
-    String
-
-
-bool : BoolProps msg -> Props msg
-bool =
-    Bool
-
-
-select : SelectProps msg -> Props msg
-select =
-    Select
-
-
-radio : RadioProps msg -> Props msg
-radio =
-    Radio
-
-
-counter : CounterProps msg -> Props msg
-counter =
-    Counter
-
-
-boolAndString : BoolAndStringProps msg -> Props msg
-boolAndString =
-    BoolAndString
-
-
-list : List (Props msg) -> Props msg
-list =
-    List
-
-
-fieldset : String -> List (Props msg) -> Props msg
-fieldset =
-    FieldSet
-
-
-field :
-    { label : String
-    , props : Props msg
-    , note : String
-    }
-    -> Props msg
-field { label, note, props } =
-    Field { label = label, note = note } props
-
-
-customize : Html msg -> Props msg
-customize =
-    Customize
 
 
 


### PR DESCRIPTION
Playgroundの右カラムに表示する各フィールドのスタイルを更新します。
さらなる改良の余地を残していますが、実用範囲まで底上げできたかなという感じです。

CSSで記述している箇所はざっと流して見るだけで大丈夫。

![127 0 0 1_9000_](https://github.com/y047aka/elm-emaki/assets/7818994/d80b5bde-39e2-41f6-9d21-dfefae142b56)
