### PR TITLE
[package] List or Fieldset or...

### DIFF
--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -174,7 +174,7 @@ progressPlayground isDarkMode pm =
                 , Props.comment "A progress element can contain a bar visually indicating progress"
                 ]
             , Props.list
-                [ Props.header "Config" (UpdateProgress (\pm_ -> { pm_ | indicating = False, state = Default }))
+                [ Props.header "Config"
                 , Props.field "Indicating"
                     (Props.bool
                         { id = "indicating"
@@ -253,7 +253,7 @@ progressPlayground isDarkMode pm =
                     )
                 ]
             , Props.list
-                [ Props.header "Content" (UpdateProgress (\pm_ -> { pm_ | unit = "%", caption = "Uploading Files" }))
+                [ Props.header "Content"
                 , Props.field "Unit"
                     (Props.string
                         { value = pm.unit
@@ -334,17 +334,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                 )
             , Props.list
                 [ Props.header "Typography"
-                    (UpdateTypography
-                        (\tm_ ->
-                            { init_TypographyModel
-                                | webkitFontSmoothing = tm_.webkitFontSmoothing
-                                , typography =
-                                    init_TypographyModel.typography
-                                        |> Typography.setWordBreak (Maybe.withDefault Normal_WordBreak tm_.typography.textBlock.wordBreak)
-                                        |> Typography.setOverflowWrap (Maybe.withDefault Normal_OverflowWrap tm_.typography.textBlock.overflowWrap)
-                            }
-                        )
-                    )
                 , Props.field "font-family"
                     (Props.select
                         { value = tm.typography.font.families |> String.concat
@@ -580,16 +569,6 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                 ]
             , Props.list
                 [ Props.header "TextBlock"
-                    (UpdateTypography
-                        (\tm_ ->
-                            { tm_
-                                | typography =
-                                    tm_.typography
-                                        |> Typography.setWordBreak Normal_WordBreak
-                                        |> Typography.setOverflowWrap Normal_OverflowWrap
-                            }
-                        )
-                    )
                 , Props.field "word-break"
                     (Props.select
                         { value = tm.typography.textBlock.wordBreak |> Maybe.map Typography.wordBreakToString |> Maybe.withDefault "-"

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -162,7 +162,7 @@ progressPlayground isDarkMode pm =
         { isDarkMode = isDarkMode
         , preview = Progress.progressWithProps pm
         , props =
-            [ Props.FieldSet ""
+            [ Props.list
                 [ Props.field "Bar"
                     (Props.counter
                         { value = pm.value
@@ -173,8 +173,9 @@ progressPlayground isDarkMode pm =
                     )
                 , Props.comment "A progress element can contain a bar visually indicating progress"
                 ]
-            , Props.FieldSet "Config"
-                [ Props.field "Indicating"
+            , Props.list
+                [ Props.header "Config"
+                , Props.field "Indicating"
                     (Props.bool
                         { id = "indicating"
                         , value = pm.indicating
@@ -251,8 +252,9 @@ progressPlayground isDarkMode pm =
                             ""
                     )
                 ]
-            , Props.FieldSet "Content"
-                [ Props.field "Unit"
+            , Props.list
+                [ Props.header "Content"
+                , Props.field "Unit"
                     (Props.string
                         { value = pm.unit
                         , onInput = (\string ps -> { ps | unit = string }) >> UpdateProgress
@@ -330,8 +332,9 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                             >> UpdateTypography
                     }
                 )
-            , Props.FieldSet "Typography"
-                [ Props.field "font-family"
+            , Props.list
+                [ Props.header "Typography"
+                , Props.field "font-family"
                     (Props.select
                         { value = tm.typography.font.families |> String.concat
                         , options = [ Css.sansSerif.value, Css.serif.value ]
@@ -564,8 +567,9 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                         }
                     )
                 ]
-            , Props.FieldSet "TextBlock"
-                [ Props.field "word-break"
+            , Props.list
+                [ Props.header "TextBlock"
+                , Props.field "word-break"
                     (Props.select
                         { value = tm.typography.textBlock.wordBreak |> Maybe.map Typography.wordBreakToString |> Maybe.withDefault "-"
                         , options = [ "normal", "break-all", "keep-all", "auto-phrase" ]

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -174,7 +174,7 @@ progressPlayground isDarkMode pm =
                 , Props.comment "A progress element can contain a bar visually indicating progress"
                 ]
             , Props.list
-                [ Props.header "Config"
+                [ Props.header "Config" (UpdateProgress (\pm_ -> { pm_ | indicating = False, state = Default }))
                 , Props.field "Indicating"
                     (Props.bool
                         { id = "indicating"
@@ -253,7 +253,7 @@ progressPlayground isDarkMode pm =
                     )
                 ]
             , Props.list
-                [ Props.header "Content"
+                [ Props.header "Content" (UpdateProgress (\pm_ -> { pm_ | unit = "%", caption = "Uploading Files" }))
                 , Props.field "Unit"
                     (Props.string
                         { value = pm.unit
@@ -334,6 +334,17 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                 )
             , Props.list
                 [ Props.header "Typography"
+                    (UpdateTypography
+                        (\tm_ ->
+                            { init_TypographyModel
+                                | webkitFontSmoothing = tm_.webkitFontSmoothing
+                                , typography =
+                                    init_TypographyModel.typography
+                                        |> Typography.setWordBreak (Maybe.withDefault Normal_WordBreak tm_.typography.textBlock.wordBreak)
+                                        |> Typography.setOverflowWrap (Maybe.withDefault Normal_OverflowWrap tm_.typography.textBlock.overflowWrap)
+                            }
+                        )
+                    )
                 , Props.field "font-family"
                     (Props.select
                         { value = tm.typography.font.families |> String.concat
@@ -569,6 +580,16 @@ Have Resolved to Combine our Efforts to Accomplish these Aims""" ]
                 ]
             , Props.list
                 [ Props.header "TextBlock"
+                    (UpdateTypography
+                        (\tm_ ->
+                            { tm_
+                                | typography =
+                                    tm_.typography
+                                        |> Typography.setWordBreak Normal_WordBreak
+                                        |> Typography.setOverflowWrap Normal_OverflowWrap
+                            }
+                        )
+                    )
                 , Props.field "word-break"
                     (Props.select
                         { value = tm.typography.textBlock.wordBreak |> Maybe.map Typography.wordBreakToString |> Maybe.withDefault "-"

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -2,7 +2,7 @@ module Emaki.Props exposing
     ( Props
     , StringProps, BoolProps, SelectProps, RadioProps, CounterProps, BoolAndStringProps
     , render
-    , header, comment, string, bool, select, radio, counter, boolAndString
+    , comment, header, string, bool, select, radio, counter, boolAndString
     , list
     , field
     , customize
@@ -13,7 +13,7 @@ module Emaki.Props exposing
 @docs Props
 @docs StringProps, BoolProps, SelectProps, RadioProps, CounterProps, BoolAndStringProps
 @docs render
-@docs header, comment, string, bool, select, radio, counter, boolAndString
+@docs comment, header, string, bool, select, radio, counter, boolAndString
 @docs list
 @docs field
 @docs customize
@@ -32,8 +32,8 @@ import Html.Styled.Events exposing (onClick, onInput)
 
 
 type Props msg
-    = Header String msg
-    | Comment String
+    = Comment String
+    | Header String msg
     | String (StringProps msg)
     | Bool (BoolProps msg)
     | Select (SelectProps msg)
@@ -90,14 +90,14 @@ type alias BoolAndStringProps msg =
     }
 
 
-header : String -> msg -> Props msg
-header =
-    Header
-
-
 comment : String -> Props msg
 comment =
     Comment
+
+
+header : String -> msg -> Props msg
+header =
+    Header
 
 
 string : StringProps msg -> Props msg
@@ -152,6 +152,15 @@ customize =
 render : Props msg -> Html msg
 render props =
     case props of
+        Comment str ->
+            div
+                [ css
+                    [ palette Palette.textOptional
+                    , empty [ display none ]
+                    ]
+                ]
+                [ text str ]
+
         Header str resetMsg ->
             Html.header [ css [ displayFlex, justifyContent spaceBetween, alignItems center, fontWeight bold ] ]
                 [ div [ css [] ] [ text str ]
@@ -171,15 +180,6 @@ render props =
                     ]
                     [ text "Reset" ]
                 ]
-
-        Comment str ->
-            div
-                [ css
-                    [ palette Palette.textOptional
-                    , empty [ display none ]
-                    ]
-                ]
-                [ text str ]
 
         String ps ->
             input

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -26,7 +26,7 @@ import Css.Global exposing (children, everything, generalSiblings, selector, typ
 import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setBorder, setColor)
 import Css.Palette.Extra exposing (paletteByState)
 import DesignToken.Palette as Palette
-import Html.Styled as Html exposing (Attribute, Html, input, text)
+import Html.Styled as Html exposing (Attribute, Html, div, input, text)
 import Html.Styled.Attributes as Attributes exposing (css, for, id, placeholder, selected, type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
 
@@ -157,7 +157,7 @@ render props =
                 [ text str ]
 
         Comment str ->
-            Html.div
+            div
                 [ css
                     [ palette Palette.textOptional
                     , empty [ display none ]
@@ -199,7 +199,7 @@ render props =
                 }
 
         Select ps ->
-            Html.div
+            div
                 [ css
                     [ display grid
                     , property "grid-template-columns" "1fr auto"
@@ -241,7 +241,7 @@ render props =
                 ]
 
         Radio ps ->
-            Html.div []
+            div []
                 (List.map
                     (\option ->
                         Html.label [ css [ display block ] ]
@@ -266,8 +266,8 @@ render props =
                 ]
 
         BoolAndString ({ data } as ps) ->
-            Html.div []
-                [ Html.div []
+            div []
+                [ div []
                     [ Html.label []
                         [ input
                             [ type_ "checkbox"
@@ -289,11 +289,11 @@ render props =
                 ]
 
         List childProps ->
-            Html.div [ css [ displayFlex, flexDirection column, rowGap (Css.em 1) ] ]
+            div [ css [ displayFlex, flexDirection column, rowGap (Css.em 1) ] ]
                 (List.map render childProps)
 
         Field label ps ->
-            Html.div
+            div
                 [ css
                     [ display grid
                     , gridTemplateColumns [ fr 1, fr 1 ]
@@ -319,7 +319,7 @@ toggleCheckbox :
     }
     -> Html msg
 toggleCheckbox props =
-    Html.styled Html.div
+    Html.styled div
         [ display grid
         , children [ everything [ gridColumn "1", gridRow "1" ] ]
         ]
@@ -431,7 +431,7 @@ toggleLabel =
 
 labeledButtons : List (Attribute msg) -> List (Html msg) -> Html msg
 labeledButtons attributes =
-    Html.div <|
+    div <|
         css
             [ cursor pointer
             , display grid
@@ -504,7 +504,7 @@ defaultPalettes =
 
 basicLabel : List (Attribute msg) -> List (Html msg) -> Html msg
 basicLabel =
-    Html.styled Html.div
+    Html.styled div
         [ display inlineBlock
         , fontSize (rem 0.85714286)
         , lineHeight (num 1)

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -1,5 +1,5 @@
 module Emaki.Props exposing
-    ( Props(..)
+    ( Props
     , StringProps, BoolProps, SelectProps, RadioProps, CounterProps, BoolAndStringProps
     , render
     , header, comment, string, bool, select, radio, counter, boolAndString

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -26,14 +26,14 @@ import Css.Global exposing (children, everything, generalSiblings, selector, typ
 import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setBorder, setColor)
 import Css.Palette.Extra exposing (paletteByState)
 import DesignToken.Palette as Palette
-import Html.Styled as Html exposing (Attribute, Html, button, div, input, text)
+import Html.Styled as Html exposing (Attribute, Html, div, input, text)
 import Html.Styled.Attributes as Attributes exposing (css, for, id, placeholder, selected, type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
 
 
 type Props msg
     = Comment String
-    | Header String msg
+    | Header String
     | String (StringProps msg)
     | Bool (BoolProps msg)
     | Select (SelectProps msg)
@@ -95,7 +95,7 @@ comment =
     Comment
 
 
-header : String -> msg -> Props msg
+header : String -> Props msg
 header =
     Header
 
@@ -163,25 +163,9 @@ render props =
 
         -- TODO: 消す
         -- https://github.com/y047aka/elm-emaki/pull/29#issue-2128470533
-        Header str resetMsg ->
+        Header str ->
             Html.header [ css [ displayFlex, justifyContent spaceBetween, alignItems center, fontWeight bold ] ]
-                [ div [ css [] ] [ text str ]
-                , button
-                    [ onClick resetMsg
-                    , css
-                        [ cursor pointer
-                        , padding2 (em 0.25) (em 0.5)
-                        , fontSize (px 12)
-                        , borderRadius (em 0.25)
-                        , paletteWithBorder (border3 (px 1) solid)
-                            { background = Just (hsla 0 0 0 0)
-                            , color = Just (hsl 210 0 0.5)
-                            , border = Just (hsl 210 0 0.5)
-                            }
-                        ]
-                    ]
-                    [ text "Reset" ]
-                ]
+                [ text str ]
 
         String ps ->
             input

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -2,7 +2,7 @@ module Emaki.Props exposing
     ( Props(..)
     , StringProps, BoolProps, SelectProps, RadioProps, CounterProps, BoolAndStringProps
     , render
-    , comment, string, bool, select, radio, counter, boolAndString
+    , header, comment, string, bool, select, radio, counter, boolAndString
     , list, fieldset
     , field
     , customize
@@ -13,7 +13,7 @@ module Emaki.Props exposing
 @docs Props
 @docs StringProps, BoolProps, SelectProps, RadioProps, CounterProps, BoolAndStringProps
 @docs render
-@docs comment, string, bool, select, radio, counter, boolAndString
+@docs header, comment, string, bool, select, radio, counter, boolAndString
 @docs list, fieldset
 @docs field
 @docs customize
@@ -32,7 +32,8 @@ import Html.Styled.Events exposing (onClick, onInput)
 
 
 type Props msg
-    = Comment String
+    = Header String
+    | Comment String
     | String (StringProps msg)
     | Bool (BoolProps msg)
     | Select (SelectProps msg)
@@ -88,6 +89,11 @@ type alias BoolAndStringProps msg =
     , onUpdate : { visible : Bool, value : String } -> msg
     , placeholder : String
     }
+
+
+header : String -> Props msg
+header =
+    Header
 
 
 comment : String -> Props msg
@@ -152,6 +158,10 @@ customize =
 render : Props msg -> Html msg
 render props =
     case props of
+        Header str ->
+            Html.div [ css [ fontWeight bold, empty [ display none ] ] ]
+                [ text str ]
+
         Comment str ->
             Html.div
                 [ css

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -3,7 +3,7 @@ module Emaki.Props exposing
     , StringProps, BoolProps, SelectProps, RadioProps, CounterProps, BoolAndStringProps
     , render
     , header, comment, string, bool, select, radio, counter, boolAndString
-    , list, fieldset
+    , list
     , field
     , customize
     )
@@ -14,7 +14,7 @@ module Emaki.Props exposing
 @docs StringProps, BoolProps, SelectProps, RadioProps, CounterProps, BoolAndStringProps
 @docs render
 @docs header, comment, string, bool, select, radio, counter, boolAndString
-@docs list, fieldset
+@docs list
 @docs field
 @docs customize
 
@@ -26,7 +26,7 @@ import Css.Global exposing (children, everything, generalSiblings, selector, typ
 import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setBorder, setColor)
 import Css.Palette.Extra exposing (paletteByState)
 import DesignToken.Palette as Palette
-import Html.Styled as Html exposing (Attribute, Html, div, input, legend, text)
+import Html.Styled as Html exposing (Attribute, Html, div, input, text)
 import Html.Styled.Attributes as Attributes exposing (css, for, id, placeholder, selected, type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
 
@@ -41,7 +41,6 @@ type Props msg
     | Counter (CounterProps msg)
     | BoolAndString (BoolAndStringProps msg)
     | List (List (Props msg))
-    | FieldSet String (List (Props msg))
     | Field String (Props msg)
     | Customize (Html msg)
 
@@ -136,11 +135,6 @@ list =
     List
 
 
-fieldset : String -> List (Props msg) -> Props msg
-fieldset =
-    FieldSet
-
-
 field : String -> Props msg -> Props msg
 field label props =
     Field label props
@@ -159,7 +153,7 @@ render : Props msg -> Html msg
 render props =
     case props of
         Header str ->
-            Html.div [ css [ fontWeight bold, empty [ display none ] ] ]
+            Html.header [ css [ fontWeight bold, empty [ display none ] ] ]
                 [ text str ]
 
         Comment str ->
@@ -297,19 +291,6 @@ render props =
         List childProps ->
             div [ css [ displayFlex, flexDirection column, rowGap (Css.em 1) ] ]
                 (List.map render childProps)
-
-        FieldSet label childProps ->
-            Html.div
-                [ css
-                    [ displayFlex
-                    , flexDirection column
-                    , rowGap (Css.em 1)
-                    , borderWidth zero
-                    ]
-                ]
-            <|
-                legend [ css [ padding zero, fontWeight bold, empty [ display none ] ] ] [ text label ]
-                    :: List.map render childProps
 
         Field label ps ->
             div

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -21,7 +21,7 @@ module Emaki.Props exposing
 -}
 
 import Css exposing (..)
-import Css.Extra exposing (fr, grid, gridColumn, gridRow, gridTemplateColumns, rowGap)
+import Css.Extra exposing (columnGap, fr, grid, gridColumn, gridRow, gridTemplateColumns, rowGap)
 import Css.Global exposing (children, everything, generalSiblings, selector, typeSelector)
 import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setBorder, setColor)
 import Css.Palette.Extra exposing (paletteByState)
@@ -314,6 +314,7 @@ render props =
                     [ display grid
                     , gridTemplateColumns [ fr 1, fr 1 ]
                     , alignItems center
+                    , columnGap (em 0.25)
                     ]
                 ]
                 [ Html.label [] [ text label ]

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -161,6 +161,8 @@ render props =
                 ]
                 [ text str ]
 
+        -- TODO: 消す
+        -- https://github.com/y047aka/elm-emaki/pull/29#issue-2128470533
         Header str resetMsg ->
             Html.header [ css [ displayFlex, justifyContent spaceBetween, alignItems center, fontWeight bold ] ]
                 [ div [ css [] ] [ text str ]

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -26,7 +26,7 @@ import Css.Global exposing (children, everything, generalSiblings, selector, typ
 import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setBorder, setColor)
 import Css.Palette.Extra exposing (paletteByState)
 import DesignToken.Palette as Palette
-import Html.Styled as Html exposing (Attribute, Html, div, input, text)
+import Html.Styled as Html exposing (Attribute, Html, input, text)
 import Html.Styled.Attributes as Attributes exposing (css, for, id, placeholder, selected, type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
 
@@ -266,8 +266,8 @@ render props =
                 ]
 
         BoolAndString ({ data } as ps) ->
-            div []
-                [ div []
+            Html.div []
+                [ Html.div []
                     [ Html.label []
                         [ input
                             [ type_ "checkbox"
@@ -289,11 +289,11 @@ render props =
                 ]
 
         List childProps ->
-            div [ css [ displayFlex, flexDirection column, rowGap (Css.em 1) ] ]
+            Html.div [ css [ displayFlex, flexDirection column, rowGap (Css.em 1) ] ]
                 (List.map render childProps)
 
         Field label ps ->
-            div
+            Html.div
                 [ css
                     [ display grid
                     , gridTemplateColumns [ fr 1, fr 1 ]

--- a/package/src/Emaki/Props.elm
+++ b/package/src/Emaki/Props.elm
@@ -26,13 +26,13 @@ import Css.Global exposing (children, everything, generalSiblings, selector, typ
 import Css.Palette as Palette exposing (Palette, palette, paletteWithBorder, setBackground, setBorder, setColor)
 import Css.Palette.Extra exposing (paletteByState)
 import DesignToken.Palette as Palette
-import Html.Styled as Html exposing (Attribute, Html, div, input, text)
+import Html.Styled as Html exposing (Attribute, Html, button, div, input, text)
 import Html.Styled.Attributes as Attributes exposing (css, for, id, placeholder, selected, type_, value)
 import Html.Styled.Events exposing (onClick, onInput)
 
 
 type Props msg
-    = Header String
+    = Header String msg
     | Comment String
     | String (StringProps msg)
     | Bool (BoolProps msg)
@@ -90,7 +90,7 @@ type alias BoolAndStringProps msg =
     }
 
 
-header : String -> Props msg
+header : String -> msg -> Props msg
 header =
     Header
 
@@ -152,9 +152,25 @@ customize =
 render : Props msg -> Html msg
 render props =
     case props of
-        Header str ->
-            Html.header [ css [ fontWeight bold, empty [ display none ] ] ]
-                [ text str ]
+        Header str resetMsg ->
+            Html.header [ css [ displayFlex, justifyContent spaceBetween, alignItems center, fontWeight bold ] ]
+                [ div [ css [] ] [ text str ]
+                , button
+                    [ onClick resetMsg
+                    , css
+                        [ cursor pointer
+                        , padding2 (em 0.25) (em 0.5)
+                        , fontSize (px 12)
+                        , borderRadius (em 0.25)
+                        , paletteWithBorder (border3 (px 1) solid)
+                            { background = Just (hsla 0 0 0 0)
+                            , color = Just (hsl 210 0 0.5)
+                            , border = Just (hsl 210 0 0.5)
+                            }
+                        ]
+                    ]
+                    [ text "Reset" ]
+                ]
 
         Comment str ->
             div


### PR DESCRIPTION
`Props.List`と`Props.FieldSet`の機能が一部重複しているので、どちらかに寄せたい。

このPRでは`Props.List`に寄せてみました。
見出し部分の機能は`Props.header`に移譲。

ただしどの方式が良いのかはまだ決めかねています。
Decoderっぽくlistを使うようにしたものの、レンダリングの都合上、listをネストするような使い方はできない（できるけど、そうする意味がない）。
それよりは潔くFieldSetなどより具体的な用途に特化した表現のほうが良いのかもしれない。

突き詰めていくと、
```diff
playground :
    { isDarkMode : Bool
    , preview : Html msg
-   , props : List (Props msg)
+   , propsSections : List { heading : String, props : List (Props msg) }
    }
```
のように、playground関数な側で巻き取るほうが書き味は良い可能性もある。
この辺りの助言をもらいたいです。

また、判断材料として新機能（Propsをグループ単位でリセットするボタン）を追加しました。
別案として、同じ位置にグループ単位での折り畳み機能を設置することも考えられますが、emakiの使い方だと折り畳みを必要とする場面はあまりないと判断。