### PR TITLE
Emakiが将来どうなるかのスケッチを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ emaki = [
 $ npx elm-emaki
 ```
 
-## 将来的なemakiの例
+## 将来的な emaki の例
 
-動作を見たいview関数の実装`someView : Args -> Html msg`があった時、emakiファイルをこんな
+動作を見たい view 関数の実装`someView : Args -> Html msg`があった時、emaki ファイルをこんな
 感じに書くと動作確認できる画面ができる予定。
-
 
 ```elm
 import Emaki

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ main =
     Emaki.chapters
         [ Emaki.chapter
             { view = view
-            , props =
+            , controls =
                 [ Emaki.text
                     { init = ""
                     , label = "user name"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import YourProject.UserProfileCard (view)
 
 
 -- viewはこんな感じのものを想定
--- view : { userName : String, active : Boolean } -> Html msg
+-- view : { userName : String, active : Bool } -> Html msg
 
 
 main : Emaki.Emaki

--- a/README.md
+++ b/README.md
@@ -26,3 +26,42 @@ emaki = [
 ```shell
 $ npx elm-emaki
 ```
+
+## 将来的なemakiの例
+
+動作を見たいview関数の実装`someView : Args -> Html msg`があった時、emakiファイルをこんな
+感じに書くと動作確認できる画面ができる予定。
+
+
+```elm
+import Emaki
+
+
+-- elm-emakiで表示したいviewをimport
+import YourProject.UserProfileCard (view)
+
+
+-- viewはこんな感じのものを想定
+-- view : { userName : String, active : Boolean } -> Html msg
+
+
+main : Emaki.Emaki
+main =
+    Emaki.chapters
+        [ Emaki.chapter
+            { view = view
+            , props =
+                [ Emaki.text
+                    { init = ""
+                    , label = "user name"
+                    , onChange = \newValue viewProp -> { viewProp | userName = newValue }
+                    }
+                , Emaki.toggle
+                    { init = False
+                    , label = "active?"
+                    , onChange = \newValue viewProp -> { viewProp | active = newValue }
+                    }
+                ]
+            }
+        ]
+```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ main =
                     , label = "user name"
                     , onChange = \newValue viewProps -> { viewProps | userName = newValue }
                     }
-                , Emaki.toggle
+                , Control.toggle
                     { init = False
                     , label = "active?"
                     , onChange = \newValue viewProps -> { viewProps | active = newValue }

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ $ npx elm-emaki
 
 ```elm
 import Emaki
+import Emaki.Control as Control
 
 
 -- elm-emakiで表示したいviewをimport

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ main =
         [ Emaki.chapter
             { view = view
             , controls =
-                [ Emaki.text
+                [ Control.text
                     { init = ""
                     , label = "user name"
                     , onChange = \newValue viewProps -> { viewProps | userName = newValue }

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ main =
                 [ Emaki.text
                     { init = ""
                     , label = "user name"
-                    , onChange = \newValue viewProp -> { viewProp | userName = newValue }
+                    , onChange = \newValue viewProps -> { viewProps | userName = newValue }
                     }
                 , Emaki.toggle
                     { init = False

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ main =
                 , Emaki.toggle
                     { init = False
                     , label = "active?"
-                    , onChange = \newValue viewProp -> { viewProp | active = newValue }
+                    , onChange = \newValue viewProps -> { viewProps | active = newValue }
                     }
                 ]
             }


### PR DESCRIPTION
## なぜやるのか

emakiのAPIが将来的にどうなるかの方針が今のリポジトリ上で参照できないため、ざっくりとした方針があったほうが実装の方針がブレづらくなって良い

## やったこと

* README.md にまだ存在しないEmakiのexampleを追加