### PR TITLE
[package] Chapter APIを導入し、elm-emakiをより楽に記述できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,47 @@ emaki = [
 $ npx elm-emaki
 ```
 
+## Chapter API
+
+よりユーザの入力負荷を減らすための Chapter API を開発中です。
+一つのチャプターを表示するには、次のようなコードを書くことでチャプターを表示するアプリケーション
+が作成できます。
+
+```elm
+import Emaki exposing (runChapter)
+import Emaki.Chapter exposing (chapter)
+import Emaki.Chapter.Control as Control
+
+
+-- elm-emakiで表示したいviewをimport
+import YourProject.UserProfileCard (view)
+
+
+-- viewはこんな感じのものを想定
+-- view : { userName : String, active : Bool } -> Html msg
+
+
+main : Program () (Emaki.Model { userName : String, active : Bool }) Emaki.Msg
+main =
+    runChapter <|
+        chapter
+            { init = { userName = "", active = False }
+            , view = view
+            , controls =
+                [ Control.text
+                    { init = ""
+                    , label = "user name"
+                    , onChange = \newValue viewProps -> { viewProps | userName = newValue }
+                    }
+                , Control.toggle
+                    { init = False
+                    , label = "active?"
+                    , onChange = \newValue viewProps -> { viewProps | active = newValue }
+                    }
+                ]
+            }
+```
+
 ## 将来的な emaki の例
 
 動作を見たい view 関数の実装`someView : Args -> Html msg`があった時、emaki ファイルをこんな

--- a/package/elm.json
+++ b/package/elm.json
@@ -5,6 +5,9 @@
     "license": "MIT",
     "version": "0.0.0",
     "exposed-modules": [
+        "Emaki",
+        "Emaki.Chapter",
+        "Emaki.Chapter.Control",
         "Emaki.Control"
     ],
     "elm-version": "0.19.1 <= v < 0.20.0",

--- a/package/elm.json
+++ b/package/elm.json
@@ -9,7 +9,10 @@
     ],
     "elm-version": "0.19.1 <= v < 0.20.0",
     "dependencies": {
+        "elm/browser": "1.0.2 <= v < 2.0.0",
         "elm/core": "1.0.5 <= v < 2.0.0",
+        "elm/html": "1.0.0 <= v < 2.0.0",
+        "elm/json": "1.1.3 <= v < 2.0.0",
         "rtfeldman/elm-css": "18.0.0 <= v < 19.0.0",
         "y047aka/elm-css-palette": "3.0.0 <= v < 4.0.0"
     },

--- a/package/src/Emaki.elm
+++ b/package/src/Emaki.elm
@@ -1,138 +1,26 @@
-module Emaki exposing (Chapter, Control, main, runChapter, text)
+module Emaki exposing (Model, Msg, runChapter)
 
-import Array
 import Browser
-import Html exposing (Html)
+import Emaki.Chapter as Chapter exposing (Chapter)
 import Html.Styled as Styled
-import Html.Styled.Attributes exposing (type_, value)
-import Html.Styled.Events exposing (onInput)
-import Json.Decode as JD
-import Json.Encode as JE
 
 
-type Control props
-    = Control
-        { init : JE.Value
-        , view : JE.Value -> Styled.Html JE.Value
-        , updateProp : JE.Value -> props -> props
-        }
+type Model props
+    = ChapterModel (Chapter.Model props)
 
 
-type alias ChapterModel props =
-    { viewState : props
-    , controlsState : JE.Value
-    }
+type Msg
+    = ChapterMsg Chapter.Msg
 
 
-type Chapter props
-    = Chapter
-        { init : ChapterModel props
-        , view : ChapterModel props -> Styled.Html ChapterMsg
-        , update : ChapterMsg -> ChapterModel props -> ChapterModel props
-        }
-
-
-type alias ControlIndex =
-    Int
-
-
-type ChapterMsg
-    = UpdateControlAt ControlIndex JE.Value
-
-
-runChapter : Chapter props -> Program () (ChapterModel props) ChapterMsg
-runChapter (Chapter r) =
+runChapter : Chapter props -> Program () (Model props) Msg
+runChapter { init, view, update } =
     Browser.sandbox
-        { init = r.init
-        , update = r.update
-        , view = Styled.toUnstyled << r.view
-        }
-
-
-chapter :
-    { init : props
-    , view : props -> Html ChapterMsg
-    , controls : List (Control props)
-    }
-    -> Chapter props
-chapter { init, view, controls } =
-    let
-        controlInits =
-            List.map (\(Control r) -> r.init) controls
-
-        controlViews =
-            List.map (\(Control r) -> r.view) controls
-
-        controlOnChanges =
-            List.map (\(Control r) -> r.updateProp) controls
-                |> Array.fromList
-
-        chapterView : ChapterModel props -> Styled.Html ChapterMsg
-        chapterView { viewState, controlsState } =
-            Styled.div []
-                [ Styled.fromUnstyled (view viewState)
-                , controlsState
-                    |> JD.decodeValue (JD.list JD.value)
-                    |> Result.withDefault controlInits
-                    |> List.map2 (<|) controlViews
-                    |> List.map (Styled.li [] << List.singleton)
-                    |> List.indexedMap (\i -> Styled.map (UpdateControlAt i))
-                    |> Styled.ul []
-                ]
-
-        update (UpdateControlAt idx newValue) { viewState, controlsState } =
-            { viewState = Maybe.withDefault (always identity) (Array.get idx controlOnChanges) newValue viewState
-            , controlsState =
-                controlsState
-                    |> JD.decodeValue (JD.array JD.value)
-                    |> Result.map (Array.set idx newValue >> JE.array identity)
-                    |> Result.withDefault controlsState
-            }
-    in
-    Chapter
-        { init = ChapterModel init (JE.list identity controlInits)
-        , view = chapterView
-        , update = update
-        }
-
-
-text : { init : String, label : String, onChange : String -> props -> props } -> Control props
-text { init, label, onChange } =
-    Control
-        { init = JE.string init
+        { init = ChapterModel init
+        , update = \(ChapterMsg subMsg) (ChapterModel subModel) -> ChapterModel (update subMsg subModel)
         , view =
-            \v ->
-                Styled.input
-                    [ type_ "text"
-                    , onInput JE.string
-                    , value (Result.withDefault init (JD.decodeValue JD.string v))
-                    ]
-                    []
-        , updateProp =
-            \value state ->
-                JD.decodeValue JD.string value
-                    |> Result.map onChange
-                    |> Result.withDefault identity
-                    |> (\update -> update state)
+            \(ChapterModel chapterModel) ->
+                view chapterModel
+                    |> Styled.map ChapterMsg
+                    |> Styled.toUnstyled
         }
-
-
-exampleView : { userName : String } -> Html msg
-exampleView { userName } =
-    Html.text ("User Name: " ++ userName)
-
-
-main : Program () (ChapterModel { userName : String }) ChapterMsg
-main =
-    runChapter <|
-        chapter
-            { init = { userName = "" }
-            , view = exampleView
-            , controls =
-                [ text
-                    { init = "default"
-                    , label = "user name"
-                    , onChange = \newValue viewProp -> { viewProp | userName = newValue }
-                    }
-                ]
-            }

--- a/package/src/Emaki.elm
+++ b/package/src/Emaki.elm
@@ -1,0 +1,138 @@
+module Emaki exposing (Chapter, Control, main, runChapter, text)
+
+import Array
+import Browser
+import Html exposing (Html)
+import Html.Styled as Styled
+import Html.Styled.Attributes exposing (type_, value)
+import Html.Styled.Events exposing (onInput)
+import Json.Decode as JD
+import Json.Encode as JE
+
+
+type Control props
+    = Control
+        { init : JE.Value
+        , view : JE.Value -> Styled.Html JE.Value
+        , updateProp : JE.Value -> props -> props
+        }
+
+
+type alias ChapterModel props =
+    { viewState : props
+    , controlsState : JE.Value
+    }
+
+
+type Chapter props
+    = Chapter
+        { init : ChapterModel props
+        , view : ChapterModel props -> Styled.Html ChapterMsg
+        , update : ChapterMsg -> ChapterModel props -> ChapterModel props
+        }
+
+
+type alias ControlIndex =
+    Int
+
+
+type ChapterMsg
+    = UpdateControlAt ControlIndex JE.Value
+
+
+runChapter : Chapter props -> Program () (ChapterModel props) ChapterMsg
+runChapter (Chapter r) =
+    Browser.sandbox
+        { init = r.init
+        , update = r.update
+        , view = Styled.toUnstyled << r.view
+        }
+
+
+chapter :
+    { init : props
+    , view : props -> Html ChapterMsg
+    , controls : List (Control props)
+    }
+    -> Chapter props
+chapter { init, view, controls } =
+    let
+        controlInits =
+            List.map (\(Control r) -> r.init) controls
+
+        controlViews =
+            List.map (\(Control r) -> r.view) controls
+
+        controlOnChanges =
+            List.map (\(Control r) -> r.updateProp) controls
+                |> Array.fromList
+
+        chapterView : ChapterModel props -> Styled.Html ChapterMsg
+        chapterView { viewState, controlsState } =
+            Styled.div []
+                [ Styled.fromUnstyled (view viewState)
+                , controlsState
+                    |> JD.decodeValue (JD.list JD.value)
+                    |> Result.withDefault controlInits
+                    |> List.map2 (<|) controlViews
+                    |> List.map (Styled.li [] << List.singleton)
+                    |> List.indexedMap (\i -> Styled.map (UpdateControlAt i))
+                    |> Styled.ul []
+                ]
+
+        update (UpdateControlAt idx newValue) { viewState, controlsState } =
+            { viewState = Maybe.withDefault (always identity) (Array.get idx controlOnChanges) newValue viewState
+            , controlsState =
+                controlsState
+                    |> JD.decodeValue (JD.array JD.value)
+                    |> Result.map (Array.set idx newValue >> JE.array identity)
+                    |> Result.withDefault controlsState
+            }
+    in
+    Chapter
+        { init = ChapterModel init (JE.list identity controlInits)
+        , view = chapterView
+        , update = update
+        }
+
+
+text : { init : String, label : String, onChange : String -> props -> props } -> Control props
+text { init, label, onChange } =
+    Control
+        { init = JE.string init
+        , view =
+            \v ->
+                Styled.input
+                    [ type_ "text"
+                    , onInput JE.string
+                    , value (Result.withDefault init (JD.decodeValue JD.string v))
+                    ]
+                    []
+        , updateProp =
+            \value state ->
+                JD.decodeValue JD.string value
+                    |> Result.map onChange
+                    |> Result.withDefault identity
+                    |> (\update -> update state)
+        }
+
+
+exampleView : { userName : String } -> Html msg
+exampleView { userName } =
+    Html.text ("User Name: " ++ userName)
+
+
+main : Program () (ChapterModel { userName : String }) ChapterMsg
+main =
+    runChapter <|
+        chapter
+            { init = { userName = "" }
+            , view = exampleView
+            , controls =
+                [ text
+                    { init = "default"
+                    , label = "user name"
+                    , onChange = \newValue viewProp -> { viewProp | userName = newValue }
+                    }
+                ]
+            }

--- a/package/src/Emaki/Chapter.elm
+++ b/package/src/Emaki/Chapter.elm
@@ -49,7 +49,7 @@ chapter { init, view, controls } =
                     |> Result.withDefault controlInits
                     |> List.map2 (<|) controlViews
                     |> List.map (Styled.li [] << List.singleton)
-                    |> List.indexedMap (\i -> Styled.map (ChapterInternal.UpdateControlAt i))
+                    |> List.indexedMap (\i listItem -> Styled.map (ChapterInternal.UpdateControlAt i) listItem)
                     |> Styled.ul []
                 ]
 

--- a/package/src/Emaki/Chapter.elm
+++ b/package/src/Emaki/Chapter.elm
@@ -37,7 +37,7 @@ chapter { init, view, controls } =
             List.map (\(ControlInternal.Control r) -> r.view) controls
 
         controlOnChanges =
-            List.map (\(ControlInternal.Control r) -> r.updateProp) controls
+            List.map (\(ControlInternal.Control r) -> r.updateProps) controls
                 |> Array.fromList
 
         chapterView : Model props -> Styled.Html Msg

--- a/package/src/Emaki/Chapter.elm
+++ b/package/src/Emaki/Chapter.elm
@@ -1,0 +1,68 @@
+module Emaki.Chapter exposing (Chapter, Model, Msg, chapter)
+
+import Array
+import Emaki.Chapter.Control exposing (Control)
+import Emaki.Chapter.Control.Internal as ControlInternal
+import Emaki.Chapter.Internal as ChapterInternal
+import Html exposing (Html)
+import Html.Styled as Styled
+import Json.Decode as JD
+import Json.Encode as JE
+
+
+type alias Chapter props =
+    ChapterInternal.Chapter props
+
+
+type alias Model props =
+    ChapterInternal.Model props
+
+
+type alias Msg =
+    ChapterInternal.Msg
+
+
+chapter :
+    { init : props
+    , view : props -> Html Msg
+    , controls : List (Control props)
+    }
+    -> Chapter props
+chapter { init, view, controls } =
+    let
+        controlInits =
+            List.map (\(ControlInternal.Control r) -> r.init) controls
+
+        controlViews =
+            List.map (\(ControlInternal.Control r) -> r.view) controls
+
+        controlOnChanges =
+            List.map (\(ControlInternal.Control r) -> r.updateProp) controls
+                |> Array.fromList
+
+        chapterView : Model props -> Styled.Html Msg
+        chapterView { viewState, controlsState } =
+            Styled.div []
+                [ Styled.fromUnstyled (view viewState)
+                , controlsState
+                    |> JD.decodeValue (JD.list JD.value)
+                    |> Result.withDefault controlInits
+                    |> List.map2 (<|) controlViews
+                    |> List.map (Styled.li [] << List.singleton)
+                    |> List.indexedMap (\i -> Styled.map (ChapterInternal.UpdateControlAt i))
+                    |> Styled.ul []
+                ]
+
+        update (ChapterInternal.UpdateControlAt idx newValue) { viewState, controlsState } =
+            { viewState = Maybe.withDefault (always identity) (Array.get idx controlOnChanges) newValue viewState
+            , controlsState =
+                controlsState
+                    |> JD.decodeValue (JD.array JD.value)
+                    |> Result.map (Array.set idx newValue >> JE.array identity)
+                    |> Result.withDefault controlsState
+            }
+    in
+    { init = ChapterInternal.Model init (JE.list identity controlInits)
+    , view = chapterView
+    , update = update
+    }

--- a/package/src/Emaki/Chapter/Control.elm
+++ b/package/src/Emaki/Chapter/Control.elm
@@ -29,7 +29,7 @@ text r =
                     , value (Result.withDefault r.init (JD.decodeValue JD.string v))
                     ]
                     []
-        , updateProp =
+        , updateProps =
             \value state ->
                 value
                     |> JD.decodeValue JD.string

--- a/package/src/Emaki/Chapter/Control.elm
+++ b/package/src/Emaki/Chapter/Control.elm
@@ -1,0 +1,39 @@
+module Emaki.Chapter.Control exposing (Control, text)
+
+import Emaki.Chapter.Control.Internal as Internal
+import Html.Styled exposing (input)
+import Html.Styled.Attributes exposing (type_, value)
+import Html.Styled.Events exposing (onInput)
+import Json.Decode as JD
+import Json.Encode as JE
+
+
+type alias Control props =
+    Internal.Control props
+
+
+text :
+    { init : String
+    , label : String
+    , onChange : String -> props -> props
+    }
+    -> Control props
+text r =
+    Internal.Control
+        { init = JE.string r.init
+        , view =
+            \v ->
+                input
+                    [ type_ "text"
+                    , onInput JE.string
+                    , value (Result.withDefault r.init (JD.decodeValue JD.string v))
+                    ]
+                    []
+        , updateProp =
+            \value state ->
+                value
+                    |> JD.decodeValue JD.string
+                    |> Result.map r.onChange
+                    |> Result.withDefault identity
+                    |> (\update -> update state)
+        }

--- a/package/src/Emaki/Chapter/Control/Internal.elm
+++ b/package/src/Emaki/Chapter/Control/Internal.elm
@@ -1,0 +1,12 @@
+module Emaki.Chapter.Control.Internal exposing (Control(..))
+
+import Html.Styled exposing (Html)
+import Json.Encode exposing (Value)
+
+
+type Control props
+    = Control
+        { init : Value
+        , view : Value -> Html Value
+        , updateProp : Value -> props -> props
+        }

--- a/package/src/Emaki/Chapter/Control/Internal.elm
+++ b/package/src/Emaki/Chapter/Control/Internal.elm
@@ -8,5 +8,5 @@ type Control props
     = Control
         { init : Value
         , view : Value -> Html Value
-        , updateProp : Value -> props -> props
+        , updateProps : Value -> props -> props
         }

--- a/package/src/Emaki/Chapter/Internal.elm
+++ b/package/src/Emaki/Chapter/Internal.elm
@@ -1,0 +1,25 @@
+module Emaki.Chapter.Internal exposing (Chapter, Model, Msg(..))
+
+import Html.Styled exposing (Html)
+import Json.Encode exposing (Value)
+
+
+type alias Chapter props =
+    { init : Model props
+    , view : Model props -> Html Msg
+    , update : Msg -> Model props -> Model props
+    }
+
+
+type alias Model props =
+    { viewState : props
+    , controlsState : Value
+    }
+
+
+type alias ControlIndex =
+    Int
+
+
+type Msg
+    = UpdateControlAt ControlIndex Value


### PR DESCRIPTION
## なぜやるのか

既存の`Emaki.Control`は、uiをコントロールするためのviewは提供していますが、コントロールするviewの状態と、コントロールする対象のviewのモデルの統合やデータの結合をユーザが記述しなければならず、利用者にとって負荷が高い状態になっています。

このPRで作成したChapter APIは、コントロールの集まりとコントロール対象のviewを組にした`Chapter`という概念を導入し、controlの状態管理のためのコードをユーザが自前実装をしなくて良くなります。

壮大な全体の計画は下記issue参照

- https://github.com/y047aka/elm-emaki/issues/36

## このPRで実現したことサマリ

- `Emaki` モジュールがチャプターを実行するための`runChapter`をexport
- `Emaki.Chapter` が、viewとコントロールのリストを組みにした構造 `Chapter`  データ型と、それを作るための`chapter`関数をexport
- `Emaki.Chapter.Control` chapterに渡すためのコントロールたちがたくさんあるモジュールにする予定。今はtext inputの雑実装のみある

詳細はコメントに記述しました！


## このPRがmergeされた後にやる予定

* ChapterのUIをexampleから移植
* 既存のcontrolのchapter API準拠
* examleのリライト